### PR TITLE
Add more built-in python checkers

### DIFF
--- a/checkers/py-globals-as-template-context.test.py
+++ b/checkers/py-globals-as-template-context.test.py
@@ -1,0 +1,30 @@
+import base64
+import mimetypes
+import os
+
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.shortcuts import redirect, render
+from django.views.decorators.csrf import csrf_exempt
+from django.template import Template
+
+# adapted from https://github.com/mpirnat/lets-be-bad-guys/blob/7cbf11014bfc6dc9e199dc0b8a64e4597bc2338f/badguys/vulnerable/views.py#L95
+
+def file_access(request):
+    msg = request.GET.get('msg', '')
+    # <no-error>
+    return render(request, 'vulnerable/injection/file_access.html',
+            {'msg': msg})
+
+
+def bad1(request):
+    # <expect-error>
+    response = render(request, 'vulnerable/xss/form.html', globals())
+    response.set_cookie(key='monster', value='omnomnomnomnom!')
+    return response
+
+def bad3(request):
+    # <expect-error>
+    response = Template.render(request, 'vulnerable/xss/form.html', globals())
+    response.set_cookie(key='monster', value='omnomnomnomnom!')
+    return response

--- a/checkers/py-globals-as-template-context.yml
+++ b/checkers/py-globals-as-template-context.yml
@@ -1,0 +1,34 @@
+language: py
+name: globals-as-template-context
+message: Detected the usage of `globals()` as context to `render()`
+category: security
+severity: error
+
+pattern: |
+  (call
+    function: (identifier) @render
+    arguments: (argument_list
+      (_)*
+      (call
+        function: (identifier) @globals
+        arguments: (argument_list))
+      (_)*)
+    (#eq? @render "render")
+    (#eq? @globals "globals")) @globals-as-template-context
+
+  (call
+    function: (attribute
+      object: (identifier) @template
+      attribute: (identifier) @render)
+    arguments: (argument_list
+      (_)*
+      (call
+        function: (identifier) @globals
+        arguments: (argument_list))
+      (_)*)
+    (#eq? @template "Template")
+    (#eq? @render "render")
+    (#eq? @globals "globals")) @globals-as-template-context
+
+description: |
+  Using globals() in render(...) is dangerous—it exposes unintended Python functions, leading to server-side template injection (SSTI). Attackers could execute arbitrary code. Instead, pass only the required variables in a dictionary or `django.template.Context`.

--- a/checkers/py-hashid-with-django-secret.test.py
+++ b/checkers/py-hashid-with-django-secret.test.py
@@ -1,0 +1,63 @@
+# https://github.com/crowdresearch/daemo/blob/36e3b70d4e2c06b4853e9209a4916f8301ed6464/crowdsourcing/serializers/task.py#L435-L437
+from django.conf import settings
+from hashids import Hashids
+# <expect-error>
+identifier = Hashids(salt=settings.SECRET_KEY, min_length=settings.ID_HASH_MIN_LENGTH)
+
+# https://github.com/pythonitalia/pycon-quiz/blob/7fe11ab96815edad4cf1ed0bdd8ba52d9438ffa0/backend/django_hashids/hashids.py
+from django.conf import settings
+from hashids import Hashids
+
+
+def get_hashids():~
+# <expect-error>
+    return Hashids(
+        salt=settings.SECRET_KEY, min_length=4, alphabet="abcdefghijklmnopqrstuvwxyz"
+    )
+
+# https://github.com/made-with-future/django-common/blob/dc68c93209a71c63dbf0241b997ab8e67697b3a5/common/models.py#L45
+class UIDMixin(models.Model):
+
+    objects = UIDManager()
+
+    _hashids = None
+
+    def __init__(self, *args, **kwargs):
+        super(UIDMixin, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def hashids(cls):
+        if not cls._hashids:
+            md5 = hashlib.md5()
+            md5.update('{}{}'.format(settings.SECRET_KEY, cls.__name__))
+# <no-error>
+            cls._hashids = Hashids(salt=md5.hexdigest(), min_length=16)
+        return cls._hashids
+
+# https://github.com/duthaho/aicontest/blob/f6bdcc785b66842be65a8086938d198d65f27650/coding/services/util.py
+from contextlib import suppress
+import random
+import string
+
+from django.conf import settings
+from hashids import Hashids
+
+
+def get_random_string(length: int) -> str:
+    # choose from all lowercase letter
+    letters = string.ascii_lowercase + string.digits
+    return "".join(random.choice(letters) for i in range(length))
+
+
+def id_to_hash(id: int, length: int = 6) -> str:
+    alphabet = string.ascii_letters + string.digits
+# <expect-error>
+    return Hashids(settings.SECRET_KEY, min_length=length, alphabet=alphabet).encrypt(
+        id
+    )
+
+
+def safe_int(num: any, default: int = 0) -> int:
+    with suppress(Exception):
+        return int(num)
+    return default

--- a/checkers/py-hashid-with-django-secret.yml
+++ b/checkers/py-hashid-with-django-secret.yml
@@ -1,0 +1,35 @@
+language: py
+name: hashid-with-django-secret
+message: Detected usage of Django secret as salt in HashID
+category: security
+
+pattern: |
+  (call
+    function: (identifier) @hashid
+    arguments: (argument_list
+      (_)*
+      (attribute
+        object: (identifier) @settings
+        attribute: (identifier) @secretkey)
+      (_)*)
+    (#eq? @hashid "Hashids")
+    (#eq? @settings "settings")
+    (#eq? @secretkey "SECRET_KEY")) @hashid-with-django-secret
+
+  (call
+    function: (identifier) @hashid
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @salt
+        value: (attribute
+          object: (identifier) @settings
+          attribute: (identifier) @secretkey))
+      (_)*)
+    (#eq? @hashid "Hashids")
+    (#eq? @salt "salt")
+    (#eq? @settings "settings")
+    (#eq? @secretkey "SECRET_KEY")) @hashid-with-django-secret
+
+description: |
+  Django's secret key is used as salt in HashIDs, which are insecure. Attackers can recover the salt by analyzing enough HashIDs, exposing the secret key.

--- a/checkers/py-html-magic-method.test.py
+++ b/checkers/py-html-magic-method.test.py
@@ -1,0 +1,23 @@
+from django.template import Context, Template
+from django.test import SimpleTestCase
+from django.utils import html
+from django.utils.functional import lazy, lazystr
+from django.utils.safestring import SafeData, mark_safe
+
+
+# cf. https://github.com/django/django/blob/d17b380653da5f95885ce53468fe7aac60672841/tests/utils_tests/test_safestring.py#L8
+class customescape(str):
+    # <expect-error>
+    def __html__(self):
+        # Implement specific and wrong escaping in order to be able to detect
+        # when it runs.
+        return self.replace('<', '<<').replace('>', '>>')
+
+class someotherclass(str):
+    # <no-error>
+    def __init__(self):
+        print('hello')
+
+# <no-error>
+def __html__():
+    pass

--- a/checkers/py-html-magic-method.yml
+++ b/checkers/py-html-magic-method.yml
@@ -1,0 +1,15 @@
+language: py
+name: html-magic-method
+message: Detected the usage of `__html__` magic method
+category: security
+
+pattern: |
+  (function_definition
+    name: (identifier) @html
+  (#eq? @html "__html__")) @html-magic-method
+
+filters:
+  - pattern-inside: (class_definition)
+
+description:
+  The __html__ method marks a value as safe, bypassing HTML escaping and risking XSS. Use mark_safe() instead for clearer intent when rendering raw HTML.

--- a/checkers/py-jwt-python-none-alg.test.py
+++ b/checkers/py-jwt-python-none-alg.test.py
@@ -1,0 +1,16 @@
+import jwt
+
+def bad1():
+    # <expect-error>
+    encoded = jwt.encode({'some': 'payload'}, None, algorithm='none')
+    return encoded
+
+def bad2(encoded):
+    # <expect-error>
+    jwt.decode(encoded, None, algorithms=['none'])
+    return encoded
+
+def ok(secret_key):
+    # <no-error>
+    encoded = jwt.encode({'some': 'payload'}, secret_key, algorithm='HS256')
+    return encoded

--- a/checkers/py-jwt-python-none-alg.yml
+++ b/checkers/py-jwt-python-none-alg.yml
@@ -1,0 +1,42 @@
+language: py
+name: jwt-python-none-alg
+message: Detected the usage of `none` in the algorithms parameter in JWT token
+category: security
+
+pattern: |
+  (call
+    function: (attribute
+      object: (identifier) @jwt
+      attribute: (identifier) @encode)
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @algorithm
+        value: (string
+          (string_content) @none))
+      (_)*)
+    (#eq? @jwt "jwt")
+    (#eq? @encode "encode")
+    (#eq? @algorithm "algorithm")
+    (#eq? @none "none")) @jwt-python-none-alg
+
+  
+  (call
+    function: (attribute
+      object: (identifier) @jwt
+      attribute: (identifier) @decode)
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @algorithms
+        value: (list
+          (string
+            (string_content) @none)))
+      (_)*)
+    (#eq? @jwt "jwt")
+    (#eq? @decode "decode")
+    (#eq? @algorithms "algorithms")
+    (#eq? @none "none")) @jwt-python-none-alg
+
+description: |
+  The JWT token uses the 'none' algorithm, which assumes its integrity is already verified. This allows attackers to forge tokens that get automatically verified. Avoid using 'none'; use a secure algorithm like 'HS256' instead.

--- a/checkers/py-post-after-isvalid.test.py
+++ b/checkers/py-post-after-isvalid.test.py
@@ -1,0 +1,48 @@
+from django.shortcuts import render, redirect
+from .models import *
+from .forms import *
+
+
+# The idea here is to create an model object called a Tournament, with a form for creation called CreateTournamentForm()
+# 
+# Django best practices are to use form.cleaned_data[] after validation to ensure you're accessing well-sanitized data:
+# https://docs.djangoproject.com/en/4.2/ref/forms/api/#accessing-clean-data
+# 
+# Some fairly typical django form object creation handlers
+# This handler does NOT use request.cleaned_data[], even after form.is_valid() has run
+def create_new_tournament_dangerous(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <expect-error>
+            t = Tournament(name=request.POST['name'])
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)
+    
+def create_new_tournament_dangerous(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <expect-error>
+            t = Tournament(name=request.POST.get('name'))
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)
+
+# This handler DOES use request.cleaned_data[], even after form.is_valid() has run
+def create_new_tournament_safe(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <no-error>
+            t = Tournament(name=form.cleaned_data['name'])
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)

--- a/checkers/py-post-after-isvalid.yml
+++ b/checkers/py-post-after-isvalid.yml
@@ -1,0 +1,36 @@
+language: py
+name: post-after-isvalid
+message: Detected request.POST after an is_valid() check
+category: security
+
+pattern: |
+  (subscript
+    value: (attribute
+      object: (identifier) @request
+      attribute: (identifier) @post)
+    subscript: (_)
+    (#eq? @request "request")
+    (#eq? @post "POST")) @post-after-isvalid
+
+  (call
+    function: (attribute
+      object: (attribute
+        object: (identifier) @request
+        attribute: (identifier) @post)
+      attribute: (identifier) @get)
+    (#eq? @request "request")
+    (#eq? @post "POST")
+    (#eq? @get "get")) @post-after-isvalid
+
+filters:
+  - pattern-inside: |
+      (if_statement
+        condition: (call
+          function: (attribute
+            object: (identifier)
+            attribute: (identifier) @isvalid)
+          arguments: (argument_list))
+        (#eq? @isvalid "is_valid"))
+
+description: |
+  Use form.cleaned_data[] instead of request.POST[]/request.POST.get() after form.is_valid() to access only sanitized data


### PR DESCRIPTION
Implemented checkers:

- Using globals() context in django render
- Using django secret as salt in Hashid
- Using __html__ magic method
- Using `none` algorithm in JWT token encode/decode
- Using request.POST after an form.is_valid() check

Test logs:

```
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: py-avoid-marksafe.yml
Running test case: py-context-autoescape-off.yml
Running test case: py-filter-issafe.yml
Running test case: py-format-html-param.yml
Running test case: py-globals-as-template-context.yml
Running test case: py-hashid-with-django-secret.yml
Running test case: py-html-magic-method.yml
Running test case: py-jwt-python-none-alg.yml
Running test case: py-post-after-isvalid.yml
Running test case: py-safe-string-extend.yml
All tests passed%                                 
```