### PR TITLE
feat: add version flag in the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GOLANG_CROSS_VERSION  ?= v1.23
 SYSROOT_DIR     ?= sysroots
 SYSROOT_ARCHIVE ?= sysroots.tar.bz2
 
+CLI_BUILD_FLAGS := -X 'globstar.dev/pkg/cli.version=$$(git describe --tags 2>/dev/null || echo dev)'
+
 .PHONY: sysroot-pack
 sysroot-pack:
 	@tar cf - $(SYSROOT_DIR) -P | pv -s $[$(du -sk $(SYSROOT_DIR) | awk '{print $1}') * 1024] | pbzip2 > $(SYSROOT_ARCHIVE)
@@ -48,7 +50,7 @@ release:
 
 .PHONY: test
 test:
-	@CGO_CFLAGS="-w" go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./pkg/... 
+	@CGO_CFLAGS="-w" go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./pkg/...
 	@go tool cover -func=coverage.out | grep total: | awk '{print "Total coverage: " $$3}'
 	@rm coverage.out
 
@@ -59,7 +61,7 @@ fmt:
 	@echo "Done."
 
 build:
-	CGO_ENABLED=1 go build -o bin/globstar ./cmd/globstar
+	CGO_ENABLED=1 go build -ldflags "$(CLI_BUILD_FLAGS)" -o bin/globstar ./cmd/globstar
 
 test-builtin-rules:
 	echo "Testing built-in rules..."

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -15,7 +15,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
   # darwin-arm64
   - id: globstar-darwin-arm64
     main: ./cmd/globstar
@@ -29,7 +29,7 @@ builds:
     goarch:
       - arm64
     ldflags:
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
   # linux-amd64
   - id: globstar-linux-amd64
     main: ./cmd/globstar
@@ -43,7 +43,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
   # linux-arm64
   - id: globstar-linux-arm64
     main: ./cmd/globstar
@@ -57,7 +57,7 @@ builds:
     goarch:
       - arm64
     ldflags:
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
   # windows-amd64
   - id: globstar-windows-amd64
     main: ./cmd/globstar
@@ -72,7 +72,7 @@ builds:
       - amd64
     ldflags:
       - buildmode=exe
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
   # windows-arm64
   - id: globstar-windows-arm64
     main: ./cmd/globstar
@@ -87,7 +87,7 @@ builds:
       - arm64
     ldflags:
       - buildmode=exe
-      - "-X 'main.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
 archives:
   - id: arch_rename
     builds:

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -50,6 +50,11 @@ func (c *Cli) Run() error {
 	}
 
 	cmd := &cli.Command{
+		Name:  "globstar",
+		Usage: "The open-source static analysis toolkit",
+		Description: `Globstar helps you write and run custom checkers for bad and insecure patterns and run them on
+your codebase with a simple command. It comes with built-in checkers that you can use out-of-the-box,\
+or you can write your own in the .globstar directory of any repository.`,
 		Commands: []*cli.Command{
 			{
 				Name:    "check",

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -49,9 +50,15 @@ func (c *Cli) Run() error {
 		return err
 	}
 
+	cli.VersionPrinter = func(cmd *cli.Command) {
+		version := strings.TrimPrefix(cmd.Version, "v")
+		fmt.Println(version)
+	}
+
 	cmd := &cli.Command{
-		Name:  "globstar",
-		Usage: "The open-source static analysis toolkit",
+		Name:    "globstar",
+		Usage:   "The open-source static analysis toolkit",
+		Version: version,
 		Description: `Globstar helps you write and run custom checkers for bad and insecure patterns and run them on
 your codebase with a simple command. It comes with built-in checkers that you can use out-of-the-box,\
 or you can write your own in the .globstar directory of any repository.`,

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,5 @@
+package cli
+
+// current version of globstar
+// this will be overridden during the build process
+var version = "dev"


### PR DESCRIPTION
This PR adds proper version information to the Globstar CLI. The changes include:

- Adding a version variable in the `pkg/cli` package that gets populated during build time
- Updating build flags in both `Makefile` and `goreleaser.yaml` to inject the version information
- Adding additional CLI info (name, usage, description)
- Using `git describe --tags` for local builds to show the current version/tag

The version can now be displayed using the `--version` flag in the CLI.

Related: #35 