### PR TITLE
Add yaml checker for exposed stacktrace

### DIFF
--- a/checkers/python/exposed-stacktrace.test.py
+++ b/checkers/python/exposed-stacktrace.test.py
@@ -1,9 +1,19 @@
+import logging
 import traceback
 
 from django.http import HttpResponse
 
+LOGGER = logging.getLogger(__name__)
 
-def debug_view():
+
+# <expect-error>
+def debug_view(request):
     error_trace = traceback.format_exc()
-    # <expect-error>
     return HttpResponse(error_trace, content_type="text/plain", status=500)
+
+
+# <no-error>
+def save_view(request):
+    tb = traceback.format_stack()
+    LOGGER.error(tb)
+    return HttpResponse("Internal Server Error", content_type="text/plain", status=500)

--- a/checkers/python/exposed-stacktrace.test.py
+++ b/checkers/python/exposed-stacktrace.test.py
@@ -1,0 +1,9 @@
+import traceback
+
+from django.http import HttpResponse
+
+
+def debug_view():
+    error_trace = traceback.format_exc()
+    # <expect-error>
+    return HttpResponse(error_trace, content_type="text/plain", status=500)

--- a/checkers/python/exposed-stacktrace.yml
+++ b/checkers/python/exposed-stacktrace.yml
@@ -1,0 +1,24 @@
+language: py
+name: exposed-stacktrace
+message: Detect exposed stack traces
+
+pattern: |
+  ((assignment
+      left: (identifier) @var
+      right: (call
+        function: (attribute
+          object: (identifier) @module
+          attribute: (identifier) @func)))
+    (return_statement
+      (call
+        function: (identifier) @resp
+        arguments: (argument_list (identifier) @stacktrace)))
+    (#eq? @module "traceback")
+    (#match? @func "format_(stack|exc|tb)")
+    (#match? @resp "(Json|Http)Response")
+    (#eq? @stacktrace @var)) @exposed-stacktrace
+
+description: |
+  Stack traces may expose sensitive information, including file paths,
+  folder structures, and internal logic. Instead of returning a stack
+  trace, use logging to monitor program behaviour safely.

--- a/checkers/python/exposed-stacktrace.yml
+++ b/checkers/python/exposed-stacktrace.yml
@@ -3,20 +3,23 @@ name: exposed-stacktrace
 message: Detect exposed stack traces
 
 pattern: |
-  ((assignment
-      left: (identifier) @var
-      right: (call
-        function: (attribute
-          object: (identifier) @module
-          attribute: (identifier) @func)))
-    (return_statement
-      (call
-        function: (identifier) @resp
-        arguments: (argument_list (identifier) @stacktrace)))
-    (#eq? @module "traceback")
-    (#match? @func "format_(stack|exc|tb)")
-    (#match? @resp "(Json|Http)Response")
-    (#eq? @stacktrace @var)) @exposed-stacktrace
+  (function_definition
+   body: (block
+  	(expression_statement
+  	 ((assignment
+  	   left: (identifier) @var
+  	   right: (call
+  		   function: (attribute
+  			      object: (identifier) @module
+  			      attribute: (identifier) @func)))))
+  	  (return_statement
+  	   (call
+              function: (identifier) @resp
+              arguments: (argument_list (identifier) @stacktrace)))
+  	  (#eq? @module "traceback")
+  	  (#match? @func "format_(stack|exc|tb)")
+  	  (#match? @resp "(Json|Http)Response")
+  	  (#eq? @stacktrace @var))) @exposed-stacktrace
 
 description: |
   Stack traces may expose sensitive information, including file paths,


### PR DESCRIPTION
### **Summary: Stack Trace Exposure Checker**  

This checker detects instances where raw stack traces generated by `traceback.format_stack()`, `traceback.format_exc()`, or `traceback.format_tb()` are directly returned in HTTP responses via `JsonResponse` or `HttpResponse`. Exposing stack traces can reveal sensitive information, such as file paths, internal logic, and application structure, increasing the risk of exploitation.  

### **Security Impact (OWASP A04:2021 – Insecure Design)**  
Improper error handling is a key aspect of **Insecure Design**, as highlighted in **OWASP A04:2021**. Returning raw stack traces compromises security by leaking implementation details, which attackers can analyze to identify vulnerabilities and craft targeted exploits. Instead of exposing stack traces, applications should log errors securely using the `logging` module and return generic error messages to users.  

### **Remediation**  
- **Log, Don’t Expose** → Use structured logging (`logging.exception()`, `logging.error()`) instead of returning stack traces in responses.  
- **Sanitize Responses** → Return user-friendly error messages without revealing internal details.  
- **Use Proper Error Handling** → Implement exception handling frameworks or middleware to manage errors securely.  
