### PR TITLE
Add "avoid-mutable-default-arg" checker for Python

### DIFF
--- a/checkers/python/avoid-mutable-default-arg.test.py
+++ b/checkers/python/avoid-mutable-default-arg.test.py
@@ -1,0 +1,10 @@
+def bad_default(arg, container=[]):  # <expect-error>
+    container.append(arg)
+    return container
+
+# This function uses None as the default and initializes the list inside the function.
+def good_default(arg, container=None):  # <no-error>
+    if container is None:
+        container = []
+    container.append(arg)
+    return container

--- a/checkers/python/avoid-mutable-default-arg.yml
+++ b/checkers/python/avoid-mutable-default-arg.yml
@@ -1,0 +1,24 @@
+language: py
+name: avoid-mutable-default-arg
+message: "Avoid using mutable default arguments in function definitions. Use None as the default and initialize the mutable object inside the function."
+category: bug-risk
+severity: error
+
+pattern: |
+  (function_definition
+    parameters: (parameters
+      (default_parameter
+        name: (identifier) @param
+        value: (list | dict | set) @mutable)))
+  (#match? @mutable "^(\\[.*\\]|\\{.*\\}|set\\(.*\\))$") @avoid-mutable-default-arg
+
+description: |
+  Mutable default arguments (like [] or {}) are evaluated only once when the function is defined.
+  This means that the same object is used in all subsequent calls to the function, which can lead
+  to unexpected behavior. Instead, use None as the default value and assign a new list or dict inside the function.
+  
+  **Example (Bad):**
+  ```python
+  def append_item(item, my_list=[]):
+      my_list.append(item)
+      return my_list


### PR DESCRIPTION
## Description:
- This PR adds a new checker to flag the use of mutable default arguments in Python function definitions.

## Why:
Mutable default arguments (like lists, dictionaries, or sets) are evaluated once at function definition time, leading to unexpected shared state across function calls. The recommended pattern is to use None as the default and initialize the mutable object inside the function.

## Example:
Bad:

```python

def append_item(item, my_list=[]):
    my_list.append(item)
    return my_list
```
Good:

```python

def append_item(item, my_list=None):
    if my_list is None:
        my_list = []
    my_list.append(item)
    return my_list
 ```