### PR TITLE
checker: go_reflect_pkg

### DIFF
--- a/checkers/go/reflect_pkg.test.go
+++ b/checkers/go/reflect_pkg.test.go
@@ -1,0 +1,38 @@
+import (
+	"fmt"
+
+	// Insecure: Use of reflect package can lead to complex, unsafe, and less readable code.
+	// <<expect-error> use of reflect package
+	"reflect"
+)
+
+func main() {
+	// Insecure Example: Using reflect to get the type of a variable
+	var x = 42
+	t := reflect.TypeOf(x)
+	fmt.Printf("Insecure (reflect): Type of x is %s\n", t)
+
+	// Why it's insecure or discouraged:
+	// - Reflect code is harder to read and maintain.
+	// - Can lead to runtime panics if used improperly.
+	// - Often used to bypass type safety, increasing risk of bugs.
+
+	// Secure Example: Use standard language features like fmt for type inspection
+	y := "Hello, Go!"
+	fmt.Printf("Secure: Value: %v, Type: %T\n", y, y)
+
+	// Secure Example: Using type assertions or type switches instead of reflect
+	checkType(y)
+}
+
+// Secure approach using type switches
+func checkType(val interface{}) {
+	switch v := val.(type) {
+	case int:
+		fmt.Println("Type is int:", v)
+	case string:
+		fmt.Println("Type is string:", v)
+	default:
+		fmt.Println("Unknown type")
+	}
+}

--- a/checkers/go/reflect_pkg.yml
+++ b/checkers/go/reflect_pkg.yml
@@ -1,0 +1,54 @@
+language: go
+name: go_reflect_pkg
+message: "Reflection is slow and should be avoided unless absolutely necessary."
+category: security
+severity: warning
+pattern: >
+  [
+    ((import_spec
+  path: (interpreted_string_literal) @import_path)
+    (#eq? @import_path "\"reflect\"")) @go_reflect_pkg
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The reflect package enables runtime type introspection and manipulation, but it comes with 
+  significant drawbacks such as poor performance, complex code, and increased risk of runtime errors. 
+  Reflection should be used only when no better alternatives (like generics or type assertions) exist.
+
+  Why this is a problem:
+  - Reflection bypasses compile-time type checking, increasing the risk of runtime panics.
+  - It introduces performance overhead, slowing down the application.
+  - Reflect-based code is harder to read, maintain, and debug.
+
+  Remediation Steps:
+  1. Use type assertions for type-safe operations:  
+     ```go
+     func printType(val interface{}) {
+       if str, ok := val.(string); ok {
+         fmt.Println("Type is string:", str)
+       }
+     }
+     ```
+  2. Use type switches for handling multiple types:  
+     ```go
+     func printType(val interface{}) {
+       switch v := val.(type) {
+       case int:
+         fmt.Println("int:", v)
+       case string:
+         fmt.Println("string:", v)
+       default:
+         fmt.Println("unknown type")
+       }
+     }
+     ```
+  3. Leverage generics (Go 1.18+) to avoid reflection:  
+     ```go
+     func printValue[T any](val T) {
+       fmt.Printf("Value: %v, Type: %T\n", val, val)
+     }
+     ```


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect the use of the `reflect` package, which should be avoided unless absolutely necessary due to performance and maintainability concerns.

### Detection Logic
#### Reflection Usage in Go
This checker flags instances where:
- The `reflect` package is imported in a Go file.

### Recommended Alternatives
#### Avoid Reflection in Favor of Safer Alternatives
Reflection should only be used when no better alternatives (such as generics or type assertions) exist.

##### Insecure Example:
```go
import (
    "reflect"
)

func getTypeName(val interface{}) string {
    return reflect.TypeOf(val).Name() // Reflection introduces runtime overhead
}
```

##### Secure Example:
###### Using Type Assertions:
```go
func printType(val interface{}) {
    if str, ok := val.(string); ok {
        fmt.Println("Type is string:", str)
    }
}
```

###### Using Type Switches:
```go
func printType(val interface{}) {
    switch v := val.(type) {
    case int:
        fmt.Println("int:", v)
    case string:
        fmt.Println("string:", v)
    default:
        fmt.Println("unknown type")
    }
}
```

###### Using Generics (Go 1.18+):
```go
func printValue[T any](val T) {
    fmt.Printf("Value: %v, Type: %T\n", val, val)
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[Go Reflection](https://golang.org/pkg/reflect/)](https://golang.org/pkg/reflect/)