### PR TITLE
checker: go_samesite_cookie

### DIFF
--- a/checkers/go/samesite_cookie.test.go
+++ b/checkers/go/samesite_cookie.test.go
@@ -1,0 +1,37 @@
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// Insecure: SameSite=None without Secure flag (CSRF vulnerability)
+	// <expect-error>
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "123456",
+		SameSite: http.SameSiteNoneMode,
+	})
+
+	// Insecure: Missing SameSite attribute (defaults to SameSiteDefaultMode, can be risky)
+	// <expect-error>
+	http.SetCookie(w, &http.Cookie{
+		Name:  "session",
+		Value: "123456",
+	})
+
+	// Secure: SameSite set to LaxMode (recommended for most cases)
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session",
+		Value:    "123456",
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	// Secure: SameSite set to StrictMode (maximum CSRF protection)
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_strict",
+		Value:    "7891011",
+		SameSite: http.SameSiteStrictMode,
+	})
+
+	fmt.Fprintln(w, "Cookies set!")
+}

--- a/checkers/go/samesite_cookie.yml
+++ b/checkers/go/samesite_cookie.yml
@@ -1,0 +1,75 @@
+language: go
+name: go_samesite_cookie
+message: "Avoid using SameSite=None attribute in cookies to prevent CSRF attacks."
+category: security
+severity: critical
+pattern: >
+    (
+      (
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @_pkg
+          (#eq? @_pkg "http")
+          field: (field_identifier) @_func
+          (#eq? @_func "SetCookie")
+        )
+        arguments: (argument_list
+          (unary_expression
+            operand: (composite_literal
+              type: (qualified_type
+                package: (package_identifier) @_cookie_pkg
+                (#eq? @_cookie_pkg "http")
+                name: (type_identifier) @_type
+                (#eq? @_type "Cookie")
+              )
+              body: (literal_value) @value
+              
+                (#not-match? @value "(.*SameSiteLaxMode|.*SameSiteStrictMode)")
+              )
+            )
+          )
+        )
+    )
+    )@go_samesite_cookie
+
+    
+
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Using the SameSite=None attribute in cookies can make your application vulnerable to 
+  Cross-Site Request Forgery (CSRF) attacks, potentially allowing attackers to perform unauthorized 
+  actions on behalf of authenticated users. 
+
+  Why this is a problem:
+  - Cookies with SameSite=None are sent with cross-origin requests, enabling CSRF attacks.
+  - Sensitive operations (e.g., financial transactions) can be triggered by malicious third-party sites.
+  - It exposes user data to potential data leakage through cross-site requests.
+
+  Remediation Steps:
+  1. Use SameSite=Lax (recommended for most scenarios):  
+     Allows safe navigation while mitigating CSRF risks.
+     ```go
+     http.SetCookie(w, &http.Cookie{
+       Name:     "session_id",
+       Value:    "secure_value",
+       SameSite: http.SameSiteLaxMode,
+     })
+     ```
+  2. Use SameSite=Strict (for maximum security):  
+     Restricts cookies to same-site requests only, ideal for sensitive applications.
+     ```go
+     http.SetCookie(w, &http.Cookie{
+       Name:     "session_id",
+       Value:    "secure_value",
+       SameSite: http.SameSiteStrictMode,
+     })
+     ```
+  3. Only use SameSite=None when absolutely necessary:  
+     If cross-origin requests are required, ensure `Secure: true` is set and use additional CSRF mitigations.
+
+
+  


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect insecure usage of the `SameSite=None` attribute in cookies, which can increase the risk of Cross-Site Request Forgery (CSRF) attacks.

### Detection Logic
#### Insecure SameSite=None Usage
This checker flags instances where:
- `http.SetCookie()` is called without setting `SameSite=Lax` or `SameSite=Strict`, potentially allowing CSRF attacks.
- The `SameSite=None` attribute is used without additional security mitigations.

### Recommended Alternatives
#### Secure Cookie Configuration
To mitigate CSRF risks, configure cookies with appropriate `SameSite` attributes:

##### Insecure Example (SameSite=None - Avoid):
```go
http.SetCookie(w, &http.Cookie{
    Name:  "session_id",
    Value: "secure_value",
    SameSite: http.SameSiteNoneMode, //  Insecure: Allows cross-origin requests
})
```

##### Secure Example (SameSite=Lax - Recommended):
```go
http.SetCookie(w, &http.Cookie{
    Name:     "session_id",
    Value:    "secure_value",
    SameSite: http.SameSiteLaxMode, //  Secure: Mitigates CSRF risks
})
```

##### Secure Example (SameSite=Strict - Maximum Security):
```go
http.SetCookie(w, &http.Cookie{
    Name:     "session_id",
    Value:    "secure_value",
    SameSite: http.SameSiteStrictMode, // Most restrictive option
})
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[SameSite Cookie Attribute Explained](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)