### PR TITLE
checker: go_ssh_insecure_ignore_host

### DIFF
--- a/checkers/go/ssh_insecure_ignore_host.test.go
+++ b/checkers/go/ssh_insecure_ignore_host.test.go
@@ -1,0 +1,46 @@
+import (
+	"fmt"
+	"golang.org/x/crypto/ssh"
+	"log"
+)
+
+func test() {
+	user := "your-username"
+	password := "your-password"
+	host := "your-server:22"
+
+	// Insecure configuration (not recommended)
+	// <expect-error> usage of InsecureIgnoreHostKey
+	insecureConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), 
+	}
+
+	fmt.Println("Attempting insecure SSH connection...")
+	client, err := ssh.Dial("tcp", host, insecureConfig)
+	if err != nil {
+		log.Fatalf("Failed to connect: %v", err)
+	}
+	defer client.Close()
+	fmt.Println("Insecure SSH connection established.")
+
+	// Safe configuration (recommended)
+	safeConfig := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: nil, // Safe - forces proper host key verification
+	}
+
+	fmt.Println("Attempting safe SSH connection...")
+	clientSafe, err := ssh.Dial("tcp", host, safeConfig)
+	if err != nil {
+		log.Fatalf("Failed to connect: %v", err)
+	}
+	defer clientSafe.Close()
+	fmt.Println("Safe SSH connection established.")
+}

--- a/checkers/go/ssh_insecure_ignore_host.yml
+++ b/checkers/go/ssh_insecure_ignore_host.yml
@@ -1,0 +1,65 @@
+language: go
+name: go_ssh_insecure_ignore_host
+message: "Avoid ignoring SSH host key verification to prevent insecure connections."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+  (short_var_declaration
+    right: (expression_list
+      (unary_expression
+        operand: (composite_literal
+          type: (qualified_type
+            package: (package_identifier) @ssh_pkg
+            (#eq? @ssh_pkg "ssh")
+            name: (type_identifier) @config_type)
+            (#eq? @config_type "ClientConfig")
+          body: (literal_value
+            (keyed_element
+              (literal_element 
+                (identifier) @callback_field)
+                (#eq? @callback_field "HostKeyCallback")
+              (literal_element
+                (call_expression
+                  function: (selector_expression
+                    operand: (identifier) @ssh_pkg2
+                    (#eq? @ssh_pkg2 "ssh")
+                    field: (field_identifier) @insecure_method
+                    (#eq? @insecure_method "InsecureIgnoreHostKey")
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+  ) @go_ssh_insecure_ignore_host
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The use of ssh.InsecureIgnoreHostKey() disables host key verification, creating a critical security risk.
+  Attackers could perform a man-in-the-middle (MITM) attack, intercepting sensitive data or executing unauthorized commands.
+  
+  Remediation:
+  Instead of using `ssh.InsecureIgnoreHostKey()`, verify host keys securely by providing a known host key callback, such as:
+
+  ```go
+  hostKeyCallback, err := ssh.FixedHostKey(<trusted_host_key>)
+  if err != nil {
+      log.Fatalf("Failed to parse host key: %v", err)
+  }
+  
+  config := &ssh.ClientConfig{
+      User: user,
+      Auth: []ssh.AuthMethod{
+          ssh.Password(password),
+      },
+      HostKeyCallback: hostKeyCallback,
+  }


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect insecure SSH client configurations that ignore host key verification.

### Detection Logic
#### Insecure SSH Host Key Verification
This checker flags instances where:
- `ssh.InsecureIgnoreHostKey()` is used as the `HostKeyCallback` in `ssh.ClientConfig`, which disables SSH host key verification.

### Recommended Alternatives
#### Secure SSH Client Configuration
To ensure secure SSH connections, always verify the server’s host key using a trusted callback:

##### Insecure Example:
```go
config := &ssh.ClientConfig{
    User: "user",
    Auth: []ssh.AuthMethod{
        ssh.Password("password"),
    },
    HostKeyCallback: ssh.InsecureIgnoreHostKey(), // Insecure: Skips host key verification
}
```

##### Secure Example:
```go
hostKeyCallback, err := ssh.FixedHostKey(<trusted_host_key>)
if err != nil {
    log.Fatalf("Failed to parse host key: %v", err)
}

config := &ssh.ClientConfig{
    User: "user",
    Auth: []ssh.AuthMethod{
        ssh.Password("password"),
    },
    HostKeyCallback: hostKeyCallback, // Secure: Verifies server’s host key
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)