### PR TITLE
checker: go_tls_config_minver

### DIFF
--- a/checkers/go/tls_config_minver.test.go
+++ b/checkers/go/tls_config_minver.test.go
@@ -1,0 +1,45 @@
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func test() {
+	// Insecure: tls.Config without MinVersion set (allows deprecated protocols like TLS 1.0 and TLS 1.1)
+	// <expect-error> tls.Config.MinVersion is not set
+	insecureConfig := &tls.Config{
+		ServerName: "example.com",
+	}
+
+	// Attempting connection with insecure config (for demonstration purposes only)
+	insecureClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: insecureConfig,
+		},
+	}
+	_, err := insecureClient.Get("https://example.com")
+	if err != nil {
+		log.Printf("Insecure connection failed (as expected): %v\n", err)
+	}
+
+	// Secure: tls.Config with MinVersion set to tls.VersionTLS12
+	secureConfig := &tls.Config{
+		ServerName: "example.com",
+		// Safe: Enforces TLS 1.2 or higher for secure connections
+		MinVersion: tls.VersionTLS12,
+	}
+
+	secureClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: secureConfig,
+		},
+	}
+	resp, err := secureClient.Get("https://example.com")
+	if err != nil {
+		log.Fatalf("Secure connection failed: %v\n", err)
+	}
+	defer resp.Body.Close()
+
+	fmt.Println("Secure connection established with TLS version enforcement.")
+}

--- a/checkers/go/tls_config_minver.yml
+++ b/checkers/go/tls_config_minver.yml
@@ -1,0 +1,55 @@
+language: go
+name: go_tls_config_minver
+message: "Setting the MinVersion field ensures that the server only accepts secure TLS connections."
+category: security
+severity: critical
+pattern: >
+  [
+      (
+    (short_var_declaration
+      right: (expression_list
+        (unary_expression
+          operand: (composite_literal
+            type: (qualified_type
+              package: (package_identifier) @tls_pkg
+              name: (type_identifier) @config_type
+            )
+            body: (literal_value) @config.value
+            )
+          )
+        )
+      )
+      (#eq? @tls_pkg "tls")
+      (#eq? @config_type "Config")
+      (#not-match? @config.value ".*MinVersion.*")
+    ) @go_tls_config_minver
+  ]
+
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+
+description: |
+  The `MinVersion` field in the `tls.Config` struct ensures that the server only accepts secure TLS connections.
+  Omitting this field allows clients to negotiate older, deprecated versions of TLS (such as TLS 1.0 or TLS 1.1),
+  which are vulnerable to attacks like POODLE and BEAST.
+
+  Impact:
+  - Potential exposure to vulnerabilities in outdated TLS versions.
+  - Non-compliance with security standards (e.g., PCI-DSS, NIST guidelines).
+  - Increased risk of man-in-the-middle (MITM) attacks and data breaches.
+
+  Remediation:
+  Set the `MinVersion` field to `tls.VersionTLS12` or higher** to ensure strong encryption and protocol security.  
+  Prefer `tls.VersionTLS13` if both the client and server support it for improved performance and security.
+
+  secure Example (Missing `MinVersion`):
+  ```go
+  //tls.Config.MinVersion is set
+  config := &tls.Config{
+    ServerName: "example.com",
+    MinVersion: tls.VersionTLS12,
+  }
+


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect missing `MinVersion` settings in `tls.Config`, which can lead to insecure TLS connections.

### Detection Logic
#### Missing `MinVersion` in `tls.Config`
This checker flags instances where:
- A `tls.Config` struct is initialized without explicitly setting the `MinVersion` field.

### Recommended Alternatives
To enforce secure TLS versions, set `MinVersion` to `tls.VersionTLS12` or higher:

##### Insecure Example:
```go
config := &tls.Config{}
```

##### Secure Example:
```go
config := &tls.Config{
    MinVersion: tls.VersionTLS12,
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[OWASP Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)]