### PR TITLE
checker: go_tls_insecure

### DIFF
--- a/checkers/go/tls_insecure.test.go
+++ b/checkers/go/tls_insecure.test.go
@@ -1,0 +1,66 @@
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func test() {
+	// Insecure: InsecureSkipVerify set to true (disables certificate verification)
+	// <expect-error> InsecureSkipVerify is set to true
+	insecureConfig := &tls.Config{
+		ServerName:         "example.com",
+		InsecureSkipVerify: true, // ⚠️ Dangerous: Skips server certificate verification
+	}
+
+	insecureClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: insecureConfig,
+		},
+	}
+
+	_, err := insecureClient.Get("https://example.com")
+	if err != nil {
+		log.Printf("Insecure connection failed (as expected): %v\n", err)
+	} else {
+		log.Println("⚠️ Connection established without verifying the server certificate (unsafe).")
+	}
+
+	// Safe Example 1: InsecureSkipVerify not set (defaults to false)
+	safeConfigDefault := &tls.Config{
+		ServerName: "example.com",
+	}
+
+	safeClientDefault := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: safeConfigDefault,
+		},
+	}
+
+	resp, err := safeClientDefault.Get("https://example.com")
+	if err != nil {
+		log.Fatalf("Secure connection failed: %v\n", err)
+	}
+	defer resp.Body.Close()
+	fmt.Println("Secure connection established with default certificate verification.")
+
+	// Safe Example 2: InsecureSkipVerify explicitly set to false
+	safeConfigExplicit := &tls.Config{
+		ServerName:         "example.com",
+		InsecureSkipVerify: false, // 🔒 Explicitly ensures certificate verification
+	}
+
+	safeClientExplicit := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: safeConfigExplicit,
+		},
+	}
+
+	resp2, err := safeClientExplicit.Get("https://example.com")
+	if err != nil {
+		log.Fatalf("Secure connection failed: %v\n", err)
+	}
+	defer resp2.Body.Close()
+	fmt.Println("Secure connection established with explicit verification.")
+}

--- a/checkers/go/tls_insecure.yml
+++ b/checkers/go/tls_insecure.yml
@@ -1,0 +1,51 @@
+language: go
+name: go_tls_insecure
+message: "Avoid disabling TLS certificate verification to prevent insecure connections."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+    (short_var_declaration
+      right: (expression_list
+        (unary_expression
+          operand: (composite_literal
+            type: (qualified_type
+              package: (package_identifier) @tls_pkg
+              name: (type_identifier) @config_type
+            )
+            body: (literal_value) @config.value
+            )
+          )
+        )
+      )
+      (#eq? @tls_pkg "tls")
+      (#eq? @config_type "Config")
+      (#match? @config.value ".*InsecureSkipVerify.*true.*")
+    ) @go_tls_insecure
+  ]
+
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+
+description: |
+  Setting `tls.Config.InsecureSkipVerify` to `true` disables TLS certificate verification, exposing connections to man-in-the-middle (MITM) attacks.
+  Attackers can intercept and modify sensitive data, leading to potential security breaches.
+
+  **Remediation:**
+  - Always verify TLS certificates to establish trust in secure communications.
+  - Instead of `InsecureSkipVerify: true`, use a properly configured `RootCAs` from a trusted certificate authority (CA).
+
+  **Secure Example:**
+  ```go
+  rootCAs, err := x509.SystemCertPool()
+  if err != nil {
+      log.Fatalf("Failed to load system CA certificates: %v", err)
+  }
+
+  config := &tls.Config{
+      RootCAs: rootCAs,
+  }


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect insecure TLS configurations where `tls.Config.InsecureSkipVerify` is set to `true`.

### Detection Logic
This checker flags instances where:
- `tls.Config{ InsecureSkipVerify: true }` is used, which disables TLS certificate verification.

### Impact
Disabling TLS certificate verification exposes applications to **man-in-the-middle (MITM) attacks**, allowing attackers to intercept and modify sensitive data. This can compromise the confidentiality and integrity of communications.

### Recommended Alternatives
Instead of disabling certificate verification, use a properly configured **RootCAs** to ensure secure TLS connections.

#### Insecure Example:
```go
tlsConfig := &tls.Config{
    InsecureSkipVerify: true, // Insecure: Skips TLS verification
}
```

#### Secure Example:
```go
import "crypto/x509"

rootCAs, err := x509.SystemCertPool()
if err != nil {
    log.Fatalf("Failed to load system CA certificates: %v", err)
}

tlsConfig := &tls.Config{
    RootCAs: rootCAs, // Secure: Uses trusted CA certificates
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[OWASP Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)]