### PR TITLE
checker: go_unsafe_pkg

### DIFF
--- a/checkers/go/unsafe_pkg.test.go
+++ b/checkers/go/unsafe_pkg.test.go
@@ -1,0 +1,24 @@
+
+import (
+	"fmt"
+	"os"
+	// <expect-error>
+	"unsafe"
+)
+
+func unsafeOperation() {
+	var x int = 42
+	ptr := unsafe.Pointer(&x) //unsafe operation
+	fmt.Println("Unsafe operation with pointer:", ptr)
+}
+
+
+func safeOperation() {
+	fmt.Println("Safe operation without unsafe package")
+	fmt.Println("Current working directory:", os.Getwd())
+}
+
+func main() {
+	fmt.Println("Demonstrating safe and unsafe imports in Go")
+	safeOperation()
+}

--- a/checkers/go/unsafe_pkg.yml
+++ b/checkers/go/unsafe_pkg.yml
@@ -1,0 +1,33 @@
+language: go
+name: go_unsafe_pkg
+message: "Avoid using unsafe package to prevent unsafe operations."
+category: security
+severity: warning
+pattern: >
+  [
+    ((import_spec
+  path: (interpreted_string_literal) @import_path)
+    (#eq? @import_path "\"unsafe\"")) @go_unsafe_pkg
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The `unsafe` package allows low-level memory manipulation, which can bypass Go’s type safety and lead to unpredictable behavior, memory corruption, or security vulnerabilities.
+  Its use should be avoided unless absolutely necessary for performance-critical operations.
+
+  Remediation:
+  - Use standard Go libraries instead of `unsafe` wherever possible.
+  - If `unsafe` is required, ensure it is well-documented and reviewed for security implications.
+
+  Example (Unsafe Usage - Avoid):
+  ```go
+  import "unsafe"
+
+  func unsafePointerConversion() {
+      var x int = 42
+      ptr := unsafe.Pointer(&x)
+      _ = ptr
+  }


### PR DESCRIPTION
### Description
This PR introduces a new Go checker to detect the usage of the `unsafe` package, which allows low-level memory manipulation and can lead to security vulnerabilities.

### Detection Logic
This checker flags instances where:
- The `unsafe` package is imported, which can bypass Go’s type safety and lead to unpredictable behavior.

### Impact
Using the `unsafe` package can:
- Bypass Go’s memory safety guarantees, leading to memory corruption.
- Introduce hard-to-debug security vulnerabilities.
- Make code less portable and maintainable across different Go versions.

### Recommended Alternatives
#### Avoid `unsafe` Wherever Possible
Use standard Go libraries and idiomatic constructs to handle memory safely.

##### Insecure Example:
```go
import "unsafe"

func unsafePointerConversion() {
    var x int = 42
    ptr := unsafe.Pointer(&x) // Unsafe memory manipulation
    _ = ptr
}
```

##### Secure Example:
```go
func safeMemoryUsage() {
    var x int = 42
    y := x // Use standard assignment instead of unsafe.Pointer
    _ = y
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [Go `unsafe` Package Documentation](https://pkg.go.dev/unsafe)