### PR TITLE
checker: go_cgi_import

### DIFF
--- a/checkers/go/cgi_import.test.go
+++ b/checkers/go/cgi_import.test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	// <expect-error> usage of cgi package
+	"net/http/cgi"
+	"fmt"
+	"net/http"
+)
+
+func cgi_test() {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello from CGI (Insecure and Deprecated)!")
+	})
+
+	// Using the deprecated cgi package to serve HTTP requests (not recommended)
+	err := cgi.Serve(handler)
+	if err != nil {
+		fmt.Printf("Error running CGI server: %v\n", err)
+	}
+}
+
+func http_test() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello from the secure HTTP server!")
+	})
+
+	// Secure and modern way to serve HTTP requests
+	fmt.Println("Starting secure server on :8080...")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		fmt.Printf("Error starting server: %v\n", err)
+	}
+}

--- a/checkers/go/cgi_import.yml
+++ b/checkers/go/cgi_import.yml
@@ -1,0 +1,29 @@
+language: go
+name: go_cgi_import
+message: "Avoid importing 'net/http/cgi' package as it is deprecated and insecure."
+category: security
+severity: critical
+pattern: >
+  [
+    ((import_spec
+      path: (interpreted_string_literal) @import_path)
+      (#eq? @import_path "\"net/http/cgi\"")) @go_cgi_import
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The 'net/http/cgi' package is deprecated and insecure. Using it can expose applications to security vulnerabilities, including command injection and resource exhaustion.  
+  CGI-based architectures are outdated, slow, and not recommended for modern web applications.
+
+  Remediation:
+  Use the `net/http` package for building HTTP servers, which is more secure, efficient, and actively maintained:
+
+  ```go
+  // Insecure (deprecated and vulnerable)
+  import "net/http/cgi"
+
+  // Secure alternative
+  import "net/http"


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect the usage of the deprecated and insecure `net/http/cgi` package.

### Detection Logic
This checker flags instances where:
- The `net/http/cgi` package is imported in Go source files.

### Impact
The `net/http/cgi` package is deprecated and insecure, posing risks such as:
- **Command Injection**: CGI-based applications are more susceptible to command injection attacks.
- **Performance Issues**: CGI introduces additional process creation overhead, making it inefficient compared to modern web frameworks.
- **Outdated Architecture**: Modern web development favors more secure and scalable alternatives, such as HTTP handlers and middleware.

### Recommended Alternative
Instead of `net/http/cgi`, use the `net/http` package to build modern, secure HTTP servers.

##### Insecure Example:
```go
import "net/http/cgi"
```

##### Secure Example:
```go
import "net/http"
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[Go net/http package documentation](https://pkg.go.dev/net/http)](https://pkg.go.dev/net/http)