### PR TITLE
checker: go_des_weak_crypto

### DIFF
--- a/checkers/go/des_weak_crypto.test.go
+++ b/checkers/go/des_weak_crypto.test.go
@@ -1,0 +1,49 @@
+import (
+	"crypto/des"
+)
+
+func test_des() {
+	
+    ede2Key := []byte("example key 1234")
+
+	var tripleDESKey []byte
+	tripleDESKey = append(tripleDESKey, ede2Key[:16]...)
+	tripleDESKey = append(tripleDESKey, ede2Key[:8]...)
+	// <expect-error> Weak encryption cipher
+	_, err := des.NewTripleDESCipher(tripleDESKey)
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+
+import (
+	"crypto/des"
+)
+
+func test_des() {
+	
+    ede2Key := []byte("example key 1234")
+	// <expect-error> Weak encryption cipher
+	_, err := des.NewCipher(ede2Key)
+	if err != nil {
+		panic(err)
+	}
+
+}
+
+import (
+	"crypto/aes"
+)
+
+func test_aes() {
+	
+	key := []byte("example key 1234")
+	// Safe
+	_, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err)
+	}
+
+}

--- a/checkers/go/des_weak_crypto.yml
+++ b/checkers/go/des_weak_crypto.yml
@@ -1,0 +1,48 @@
+language: go
+name: go_des_weak_crypto
+message: "Avoid using DES for cryptographic operations as it is cryptographically weak."
+category: security
+severity: critical
+pattern: >
+  [
+    (call_expression
+  function: (selector_expression
+    operand: (identifier) @pkg
+    field: (field_identifier) @func
+    (#eq? @pkg "des")
+    (#match? @func "^(NewTripleDESCipher|NewCipher)$"))) @go_des_weak_crypto
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  Data Encryption Standard (DES) and Triple DES (3DES) are considered cryptographically weak and insecure. 
+  DES has a short key length (56 bits), making it highly susceptible to brute-force attacks, 
+  while 3DES, though an improvement, has also been deprecated due to security vulnerabilities and slower performance.
+
+  Impact:
+  Using DES or 3DES can expose sensitive data to attackers, compromising confidentiality and data integrity.
+
+  Remediation:
+  - Do not use DES or 3DES: Remove usage of `des.NewCipher` or `des.NewTripleDESCipher`.  
+  - Use AES instead:** Replace with the `crypto/aes` package, which provides strong encryption with 128, 192, or 256-bit keys.  
+  - Ensure secure key management:** Use properly generated keys and avoid hardcoding sensitive data.
+
+  **Secure Example:**  
+  ```go
+  import (
+    "crypto/aes"
+  )
+
+  func use_aes() {
+    
+    key := []byte("example key 1234")
+    // Safe use of aes 
+    _, err := aes.NewCipher(key)
+    if err != nil {
+      panic(err)
+    }
+  }


### PR DESCRIPTION
### Description
This PR introduces a security checker to detect the use of weak cryptographic algorithms, specifically DES and 3DES, which are considered cryptographically insecure.

### Detection Logic
#### Weak Cryptography (DES)
This checker flags instances where:
- `des.NewCipher` or `des.NewTripleDESCipher` are used, as DES and 3DES are deprecated and vulnerable to brute-force attacks.

### Recommended Alternatives
Instead of DES, use AES encryption to ensure secure cryptographic operations:

##### Insecure Example:
```go
import "crypto/des"

key := []byte("weak-key-123")
cipher, err := des.NewCipher(key) // Weak encryption
if err != nil {
    panic(err)
}
```

##### Secure Example:
```go
import "crypto/aes"

key := []byte("stronger-key-128-bit")
cipher, err := aes.NewCipher(key) // Secure encryption
if err != nil {
    panic(err)
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### Impact
Using DES or 3DES can expose sensitive data to attackers, compromising confidentiality and data integrity. AES is recommended as a more secure alternative.

### References
- [[NIST Deprecation of DES and 3DES](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)]