### PR TITLE
checker: go_fmt_print_in_prod

### DIFF
--- a/checkers/go/fmt_print_in_prod.test.go
+++ b/checkers/go/fmt_print_in_prod.test.go
@@ -1,0 +1,31 @@
+// <expect-error>
+fmt.Print()
+
+// <expect-error>
+fmt.Println()
+
+
+package main
+
+import (
+	"fmt"
+	"logger"
+)
+
+func main() {
+	// <expect-error>
+    fmt.Print("Hello, ")
+	// <expect-error>
+    fmt.Print("World!")
+	// <expect-error>
+	fmt.Println("Hello, World!") 
+	// <expect-error>
+    fmt.Println("Line 1")
+	// <expect-error>
+	fmt.Printf("Name: %s, Age: %d\n", name, age)
+
+	// Safe
+	logger.Info("Hello, World!")
+	//Safe
+	logger.Debug("Hello, World!")
+}

--- a/checkers/go/fmt_print_in_prod.yml
+++ b/checkers/go/fmt_print_in_prod.yml
@@ -1,0 +1,39 @@
+language: go
+name: go_fmt_print_in_prod
+message: "Avoid using fmt.Print* functions in production code."
+category: best-practice
+severity: warning
+pattern: >
+  (
+      (call_expression
+  function: (selector_expression
+  	operand: (identifier) @pkg
+    (#eq? @pkg "fmt")
+    field: (field_identifier) @func
+    (#match? @func "Println|Printf|Print")
+  ))
+  )
+  @go_fmt_print_in_prod
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The fmt.Print* functions (fmt.Print, fmt.Println, fmt.Printf) are convenient for debugging and development, but they should be avoided in production environments. Printing directly to standard output can:
+  - Expose sensitive information: Logs may reveal internal details to unauthorized users.
+  - Impact performance: Frequent console output can slow down applications, especially under high load.
+  - Lack flexibility: fmt doesn’t support log levels (e.g., INFO, WARN, ERROR) or structured logging, making maintenance and troubleshooting difficult in production.
+
+  Remediation:
+  - Use a logging library: Libraries like logrus, zap, or log15 provide more features and flexibility for logging in production.
+  - Implement structured logging: Use structured logging to add context to logs and make them easier to search and analyze.
+  - Set log levels: Use log levels to control the verbosity of logs and filter out unnecessary information.
+
+  Example:
+  ```go
+  // Bad
+  fmt.Println("Hello, World!")
+
+  // Good
+  log.Println("Hello, World!")


### PR DESCRIPTION
### Description
This PR introduces a new checker to discourage the use of `fmt.Print*` functions in production Go code.

### Detection Logic
This checker flags instances where:
- `fmt.Print`, `fmt.Println`, or `fmt.Printf` are used in production code.

### Issue
The `fmt.Print*` functions are convenient for debugging and development but should be avoided in production environments because:
- They can expose sensitive information to unauthorized users.
- Frequent console output can degrade application performance.
- They lack logging levels and structured logging, making maintenance and debugging more difficult.

### Recommended Alternatives
Instead of `fmt.Print*`, use a structured logging library such as `log`, `logrus`, or `zap`.

#### Insecure Example:
```go
fmt.Println("Hello, World!") // Avoid using fmt in production
```

#### Secure Example:
```go
log.Println("Hello, World!") // Use structured logging
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[Go Logging Best Practices](https://golang.org/doc/effective_go#logging)]