### PR TITLE
checker: go_grpc_client_insecure_tls

### DIFF
--- a/checkers/go/grpc_client_insecure_tls.test.go
+++ b/checkers/go/grpc_client_insecure_tls.test.go
@@ -1,0 +1,17 @@
+func unsafe() {
+	// <expect-error> insecure grpc dial
+    conn, err := grpc.Dial(address, grpc.WithInsecure())
+    if err != nil {
+        log.Fatalf("did not connect: %v", err)
+    }
+    defer conn.Close()
+}
+
+func safe() {
+	// Safe
+	conn, err := grpc.Dial(address)
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+}

--- a/checkers/go/grpc_client_insecure_tls.yml
+++ b/checkers/go/grpc_client_insecure_tls.yml
@@ -1,0 +1,71 @@
+language: go
+name: go_grpc_client_insecure_tls
+message: "Avoid using
+  grpc.WithInsecure() in gRPC client connection which disables transport security."
+category: security
+severity: critical
+pattern: >
+   (
+    (call_expression
+      function: (selector_expression
+        operand: (identifier) @_pkg
+        (#eq? @_pkg "grpc")
+        field: (field_identifier) @_dial
+        (#eq? @_dial "Dial")
+      )
+      arguments: (argument_list
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @_grpc_pkg
+            (#eq? @_grpc_pkg "grpc")
+            field: (field_identifier) @insecure_func
+            (#eq? @insecure_func "WithInsecure")
+        )
+      )
+    )
+   )) @go_grpc_client_insecure_tls
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Using grpc.WithInsecure() disables TLS (Transport Layer Security) in gRPC client connections, exposing your application to Man-in-the-Middle (MITM) attacks and other security vulnerabilities. 
+  Transport security ensures that data exchanged between clients and servers is encrypted, maintaining confidentiality and integrity.
+  Remediation:
+    Use grpc.WithTransportCredentials() with proper TLS configurations to secure communication.
+
+  InSecure Example: (Insecure - Do Not Use)
+
+  ```go
+  import (
+    "google.golang.org/grpc"
+  )
+
+  conn, err := grpc.Dial("example.com:50051", grpc.WithInsecure()) // Disables security
+  if err != nil {
+    log.Fatalf("Connection failed: %v", err)
+  }
+  defer conn.Close()
+
+  Secure Example:
+
+  ```go
+  import (
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+    "log"
+  )
+
+  func main() {
+    creds, err := credentials.NewClientTLSFromFile("server-cert.pem", "")
+    if err != nil {
+      log.Fatalf("Failed to load TLS credentials: %v", err)
+    }
+
+    conn, err := grpc.Dial("example.com:50051", grpc.WithTransportCredentials(creds)) // Secure connection
+    if err != nil {
+      log.Fatalf("Connection failed: %v", err)
+    }
+    defer conn.Close()
+  }


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect insecure usage of `grpc.WithInsecure()` in gRPC client connections. Using `grpc.WithInsecure()` disables Transport Layer Security (TLS), exposing applications to **Man-in-the-Middle (MITM) attacks**, data interception, and unauthorized access.

### Detection Logic
This checker flags instances where:
- The `grpc.Dial()` function is called with `grpc.WithInsecure()`.
- This disables TLS encryption and allows unencrypted communication between client and server.

### Recommended Alternatives
To secure gRPC client connections, use **TLS with proper certificate validation**:

#### Insecure Example (DO NOT USE):
```go
import (
    "google.golang.org/grpc"
)

conn, err := grpc.Dial("example.com:50051", grpc.WithInsecure()) // Insecure: disables transport security
if err != nil {
    log.Fatalf("Connection failed: %v", err)
}
defer conn.Close()
```

#### Secure Example:
```go
import (
    "google.golang.org/grpc"
    "google.golang.org/grpc/credentials"
    "log"
)

func main() {
    creds, err := credentials.NewClientTLSFromFile("server-cert.pem", "")
    if err != nil {
        log.Fatalf("Failed to load TLS credentials: %v", err)
    }

    conn, err := grpc.Dial("example.com:50051", grpc.WithTransportCredentials(creds)) // Secure: uses TLS encryption
    if err != nil {
        log.Fatalf("Connection failed: %v", err)
    }
    defer conn.Close()
}
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[gRPC Security Documentation](https://grpc.io/docs/guides/auth/)](https://grpc.io/docs/guides/auth/)