### PR TITLE
checker: go_grpc_server_insecure_tls

### DIFF
--- a/checkers/go/grpc_server_insecure_tls.test.go
+++ b/checkers/go/grpc_server_insecure_tls.test.go
@@ -1,0 +1,16 @@
+func unsafe() {
+	// <expect-error> insecure grpc tls server
+	s := grpc.NewServer()
+	if err = s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}
+
+
+func safe() {
+	// Safe secure grpc tls server
+	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{})))
+	if err = s.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}

--- a/checkers/go/grpc_server_insecure_tls.yml
+++ b/checkers/go/grpc_server_insecure_tls.yml
@@ -1,0 +1,46 @@
+language: go
+name: go_grpc_server_insecure_tls
+message: "Using grpc.NewServer without TLS credentials creates an insecure server. Add grpc.Creds with valid TLS credentials to secure communications."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+  (short_var_declaration
+    right: (expression_list
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @_pkg
+          field: (field_identifier) @_func
+        )
+        arguments: (argument_list) @args
+      )
+    )
+  )
+  (#eq? @_pkg "grpc")
+  (#eq? @_func "NewServer")
+  (#not-match? @args ".*Creds.*")
+  ) @go_grpc_server_insecure_tls
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue: 
+    Using `grpc.NewServer` without providing TLS credentials (`grpc.Creds`) creates a gRPC server that communicates over plaintext. This exposes the server to man-in-the-middle (MITM) attacks, allowing attackers to intercept, modify, or read sensitive data.
+
+  Impact:
+    Insecure gRPC connections can lead to data leakage, unauthorized access, and loss of confidentiality and integrity.
+
+  Remediation: 
+    Always secure gRPC servers with TLS credentials. Use `credentials.NewServerTLSFromFile(certFile, keyFile)` to load a certificate and pass it to `grpc.NewServer` using `grpc.Creds`.
+
+  Example of secure usage:
+    ```go
+    creds, err := credentials.NewServerTLSFromFile("server.crt", "server.key")
+    if err != nil {
+        log.Fatalf("Failed to load TLS keys: %v", err)
+    }
+    server := grpc.NewServer(grpc.Creds(creds))


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect insecure gRPC server configurations where `grpc.NewServer` is used without TLS credentials. Running a gRPC server without TLS exposes communications to **man-in-the-middle (MITM) attacks**, allowing attackers to intercept or manipulate sensitive data.

### Detection Logic
This checker flags instances where:
- `grpc.NewServer` is called without `grpc.Creds`, indicating the absence of TLS encryption.

### Recommended Alternatives
To secure gRPC servers, always provide TLS credentials using `grpc.Creds`:

#### Insecure Example:
```go
server := grpc.NewServer() // Insecure: No TLS credentials
```

#### Secure Example:
```go
creds, err := credentials.NewServerTLSFromFile("server.crt", "server.key")
if err != nil {
    log.Fatalf("Failed to load TLS keys: %v", err)
}
server := grpc.NewServer(grpc.Creds(creds)) // Secure: TLS enabled
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[OWASP Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html)]