### PR TITLE
checker: go_html_req_template_injection

### DIFF
--- a/checkers/go/html_req_template_injection.test.go
+++ b/checkers/go/html_req_template_injection.test.go
@@ -1,0 +1,91 @@
+import (
+	"fmt"
+	"net/http"
+	"text/template"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// <expect-error> Unsanitized user input from request form passed to template
+	userInput := r.FormValue("name")
+
+	tmpl := template.New("mytemplate")
+
+	parsedTmpl, err := tmpl.Parse("Hello, {{.Name}}!")
+	if err != nil {
+		http.Error(w, "Error parsing template", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]string{"Name": userInput}
+	err = parsedTmpl.Execute(w, data)
+	if err != nil {
+		http.Error(w, "Error executing template", http.StatusInternalServerError)
+		return
+	}
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// <expect-error> Unsanitized user input from request cookie passed to template
+	userInput := r.Cookie("session_id")
+
+	tmpl := template.New("mytemplate")
+
+	parsedTmpl, err := tmpl.Parse("Hello, {{.Name}}!")
+	if err != nil {
+		http.Error(w, "Error parsing template", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]string{"Name": userInput}
+	err = parsedTmpl.Execute(w, data)
+	if err != nil {
+		http.Error(w, "Error executing template", http.StatusInternalServerError)
+		return
+	}
+}
+
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	// <expect-error> Unsanitized user input from request query params passed to template
+	userInput := r.URL.Query().Get("name")
+
+	tmpl := template.New("mytemplate")
+
+	parsedTmpl, err := tmpl.Parse("Hello, {{.Name}}!")
+	if err != nil {
+		http.Error(w, "Error parsing template", http.StatusInternalServerError)
+		return
+	}
+
+	data := map[string]string{"Name": userInput}
+	err = parsedTmpl.Execute(w, data)
+	if err != nil {
+		http.Error(w, "Error executing template", http.StatusInternalServerError)
+		return
+	}
+}
+
+
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	userInput := r.FormValue("name")
+
+	tmpl := template.New("mytemplate")
+
+	parsedTmpl, err := tmpl.Parse("Hello, {{.Name}}!")
+	if err != nil {
+		http.Error(w, "Error parsing template", http.StatusInternalServerError)
+		return
+	}
+
+	// Sanitize user input
+	SanitizedInput := template.HTMLEscapeString(userInput)
+
+	data := map[string]string{"Name": SanitizedInput}
+	// Safe - Data contains sanitized user input
+	err = parsedTmpl.Execute(w, data)
+	if err != nil {
+		http.Error(w, "Error executing template", http.StatusInternalServerError)
+		return
+	}
+}

--- a/checkers/go/html_req_template_injection.yml
+++ b/checkers/go/html_req_template_injection.yml
@@ -1,5 +1,5 @@
 language: go
-name: go_html_req_template_injection
+name: html_req_template_injection
 message: "Rendering user-controlled data using html/template without proper sanitization may lead to template injection. Sanitize user inputs or use context-aware encoding before rendering."
 category: security
 severity: critical
@@ -55,7 +55,7 @@ pattern: >
           (#eq? @template.data @data.var)
         )
       )
-    )) @template.execution) @go_html_req_template_injection
+    )) @template.execution) @html_req_template_injection
   ]
 
 exclude:

--- a/checkers/go/html_req_template_injection.yml
+++ b/checkers/go/html_req_template_injection.yml
@@ -1,0 +1,116 @@
+language: go
+name: go_html_req_template_injection
+message: "Rendering user-controlled data using html/template without proper sanitization may lead to template injection. Sanitize user inputs or use context-aware encoding before rendering."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+  (short_var_declaration 
+    left: (expression_list (identifier) @input_var)
+    right: (expression_list 
+      (call_expression
+      	function: (_) @source_expr
+      	(#match? @source_expr "(r.Cookie|r.URL.Query\\(\\).Get|r.FormValue)")
+      )
+    )
+  )
+
+  (short_var_declaration
+    left: (expression_list
+      (identifier) @data.var
+    )
+    right: (expression_list
+      (composite_literal
+        type: (map_type) @map.type
+        body: (literal_value
+          (keyed_element
+            (literal_element
+              (interpreted_string_literal) @map.key
+            )
+            (literal_element
+              (identifier) @map.value
+              (#eq? @map.value @input_var)
+            )
+          )
+        )
+      )
+    )
+  )
+
+  (assignment_statement
+    left: (expression_list
+      (identifier) @exec.error
+    )
+    right: (expression_list
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @template.instance
+          field: (field_identifier) @exec.method
+          (#eq? @exec.method "Execute")
+        )
+        arguments: (argument_list
+          (_)
+          (_) @template.data
+          (#eq? @template.data @data.var)
+        )
+      )
+    )) @template.execution) @go_html_req_template_injection
+  ]
+
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue: 
+  Rendering user-controlled data using `html/template` without proper sanitization can lead to **Server-Side Template Injection (SSTI)**.  
+  Attackers can inject malicious code or scripts into the template, potentially leading to:  
+  - Arbitrary code execution  
+  - Data leakage  
+  - Cross-Site Scripting (XSS) attacks  
+
+  Impact: 
+  - SSTI allows attackers to manipulate the server-side template, which can compromise server integrity and data confidentiality.  
+  - Even though `html/template` auto-escapes content, improper handling of user input or using `text/template` for HTML output can bypass protections.  
+
+  Recommendation: 
+  - Always validate and sanitize user inputs before using them in templates.  
+  - Use `html/template` (not `text/template`) for rendering HTML to ensure automatic escaping.  
+  - Consider encoding input using libraries like `bluemonday` for extra safety.  
+  - Avoid directly mapping user input to template data without checks.  
+
+  Secure Code Example:
+  ```go
+  package main
+
+  import (
+      "html/template"
+      "log"
+      "net/http"
+  )
+
+  func safeHandler(w http.ResponseWriter, r *http.Request) {
+      if err := r.ParseForm(); err != nil {
+          http.Error(w, "Invalid form", http.StatusBadRequest)
+          return
+      }
+
+      // Sanitize user input
+      userInput := template.HTMLEscapeString(r.FormValue("username"))
+
+      data := map[string]string{
+          "Username": userInput,
+      }
+
+      tmpl, err := template.New("example").Parse("<h1>Hello, {{.Username}}</h1>")
+      if err != nil {
+          http.Error(w, "Template error", http.StatusInternalServerError)
+          return
+      }
+
+      if err := tmpl.Execute(w, data); err != nil {
+          http.Error(w, "Execution error", http.StatusInternalServerError)
+      }
+  }


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect security risks associated with rendering user-controlled data using `html/template` without proper sanitization. Improper handling of user inputs in templates can lead to **Server-Side Template Injection (SSTI)**, allowing attackers to execute arbitrary code, leak sensitive data, or launch Cross-Site Scripting (XSS) attacks.

### Detection Logic
This checker flags instances where:
- User-controlled input (from `r.Cookie`, `r.URL.Query().Get`, or `r.FormValue`) is directly mapped to a template.
- The template executes user input without proper sanitization.

### Recommended Alternatives
To mitigate security risks, always sanitize user inputs and ensure context-aware encoding before rendering:

#### Insecure Example:
```go
http.HandleFunc("/unsafe", func(w http.ResponseWriter, r *http.Request) {
    r.ParseForm()
    data := map[string]string{"Username": r.FormValue("username")}
    tmpl, _ := template.New("example").Parse("<h1>Hello, {{.Username}}</h1>")
    tmpl.Execute(w, data) // Vulnerable: renders unsanitized user input
})
```

#### Secure Example:
```go
http.HandleFunc("/safe", func(w http.ResponseWriter, r *http.Request) {
    r.ParseForm()
    userInput := template.HTMLEscapeString(r.FormValue("username"))
    data := map[string]string{"Username": userInput}
    tmpl, _ := template.New("example").Parse("<h1>Hello, {{.Username}}</h1>")
    tmpl.Execute(w, data) // Safe: sanitized input prevents injection
})
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[CWE-1336: Improper Neutralization of Special Elements](https://cwe.mitre.org/data/definitions/1336.html)]