### PR TITLE
checker: go_http_only_cookie

### DIFF
--- a/checkers/go/http_only_cookie.test.go
+++ b/checkers/go/http_only_cookie.test.go
@@ -1,0 +1,19 @@
+// <expect-error> httpOnly is not set
+http.SetCookie(&http.Cookie{
+    Name: "session",
+    Value: "123456",
+})
+
+// <expect-error> httpOnly is set to false
+http.SetCookie(&http.Cookie{
+    Name: "session",
+    Value: "123456",
+    HttpOnly: false
+})
+
+// Safe - setting HttpOnly to true
+http.SetCookie(&http.Cookie{
+    Name: "session",
+    Value: "123456",
+    HttpOnly: true 
+})

--- a/checkers/go/http_only_cookie.yml
+++ b/checkers/go/http_only_cookie.yml
@@ -1,0 +1,55 @@
+language: go
+name: go_http_only_cookie
+message: "  Missing HttpOnly flag in cookie configuration allows client-side scripts to access cookies, increasing the risk of session hijacking. "
+category: security
+severity: warning
+pattern: >
+  [
+    (call_expression
+  function: (selector_expression
+    operand: (identifier) @http
+    field: (field_identifier) @method
+    (#match? @http "^http$")
+    (#match? @method "^SetCookie$"))
+  arguments: (argument_list
+    (unary_expression
+      (composite_literal
+        (qualified_type
+          package: (package_identifier) @pkg
+          name: (type_identifier) @type
+          (#match? @pkg "^http$")
+          (#match? @type "^Cookie$"))
+        (literal_value) @cookie_body
+        (#not-match? @cookie_body ".*HttpOnly.*true.*"))))) @go_http_only_cookie
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue: 
+  Omitting the `HttpOnly` flag in cookies allows client-side JavaScript to access them. Attackers exploiting XSS vulnerabilities can steal these cookies, leading to session hijacking and unauthorized account access.
+
+  Impact:
+  Without the `HttpOnly` flag:  
+  - Attackers can execute scripts to read cookies via `document.cookie`.  
+  - Session tokens, authentication cookies, and sensitive data become vulnerable.  
+  - Increased risk of account compromise and data theft.  
+
+  Example of Vulnerable Code:  
+  ```go
+  http.SetCookie(w, &http.Cookie{
+      Name:  "session_token",
+      Value: "abc123",
+      Path:  "/",
+      // Missing HttpOnly flag exposes cookie to client-side scripts
+  })
+
+  Secure the cookie by adding the `HttpOnly` flag:  
+  ```go
+  http.SetCookie(w, &http.Cookie{
+      Name:     "session_token",
+      Value:    "abc123",
+      HttpOnly: true,
+  })


### PR DESCRIPTION
### Description
This PR adds a new Go checker to detect missing `HttpOnly` flags in cookie configurations. The absence of the `HttpOnly` flag allows client-side scripts to access cookies, increasing the risk of session hijacking. Attackers exploiting Cross-Site Scripting (XSS) vulnerabilities can steal session tokens, authentication cookies, and other sensitive data, leading to unauthorized account access.

### Detection Logic
This checker flags instances where an `http.Cookie` is set without the `HttpOnly` attribute:
- Calls to `http.SetCookie` where the `HttpOnly` flag is not explicitly set to `true`.

### Recommended Alternatives
To mitigate the risk of session hijacking, always set the `HttpOnly` flag when creating cookies:

#### Insecure Example:
```go
http.SetCookie(w, &http.Cookie{
    Name:  "session_token",
    Value: "abc123",
    Path:  "/",
    // Missing HttpOnly flag exposes the cookie to client-side scripts
})
```

#### Secure Example:
```go
http.SetCookie(w, &http.Cookie{
    Name:     "session_token",
    Value:    "abc123",
    HttpOnly: true,
})
```

### Exclusions
To reduce noise, this checker does not flag occurrences in:
- Test files (`test/**`, `*_test.go`, `tests/**`, `__tests__/**`)

### References
- [[OWASP Secure Cookie Guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookies)]