### PR TITLE
checker: go_insecure_cookie

### DIFF
--- a/checkers/go/go_insecure_cookie.test.go
+++ b/checkers/go/go_insecure_cookie.test.go
@@ -1,0 +1,19 @@
+// <expect-error>
+http.SetCookie(&http.Cookie{
+    Name: "session",
+    Value: "123456",
+	Secure: false,
+})
+
+// <expect-error>
+http.SetCookie(&http.Cookie{
+	Name: "session",
+	Value: "123456",
+})
+
+// Safe - setting Secure to true
+http.SetCookie(&http.Cookie{
+	Name: "session",
+	Value: "123456",
+	Secure: true
+})

--- a/checkers/go/go_insecure_cookie.yml
+++ b/checkers/go/go_insecure_cookie.yml
@@ -1,0 +1,55 @@
+language: go
+name: go_insecure_cookie
+message: "Avoid using http.SetCookie to set cookies without the Secure flag to prevent insecure cookie handling."
+category: security
+severity: critical
+pattern: >
+  [
+    (call_expression
+      function: (selector_expression
+        operand: (identifier) @http
+        field: (field_identifier) @method
+        (#match? @http "^http$")
+        (#match? @method "^SetCookie$"))
+      arguments: (argument_list
+        (unary_expression
+          (composite_literal
+            (qualified_type
+              package: (package_identifier) @pkg
+              name: (type_identifier) @type
+              (#match? @pkg "^http$")
+              (#match? @type "^Cookie$"))
+            (literal_value) @cookie_body
+            (#not-match? @cookie_body ".*Secure.*true.*"))))) @go_insecure_cookie
+  ]
+exclude:  
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  Cookies set without the `Secure` flag can be sent over unsecured HTTP connections, exposing sensitive information like session tokens to interception via Man-in-the-Middle (MitM) attacks.
+
+  Impact:  
+  - Exposes cookies to network sniffing over unsecured connections.  
+  - Increases risk of session hijacking and user account compromise.  
+  - Violates security best practices for handling sensitive cookies.  
+
+  Vulnerable Example: 
+  ```go
+  http.SetCookie(w, &http.Cookie{
+      Name:  "session_token",
+      Value: "abc123",
+      Path:  "/",
+      //Missing Secure flag - cookie can be sent over HTTP
+  })
+
+  Remediation:
+  Ensure that all cookies are set with the `Secure` flag to prevent them from being sent over unsecured connections.  
+  ```go
+  http.SetCookie(w, &http.Cookie{
+      Name:   "session_token",
+      Value:  "abc123",
+      Secure: true, //Set Secure flag to true
+    })


### PR DESCRIPTION
Issue:
  Creating an `http.Client` without specifying a `Timeout` leads to requests that **never time out**.  
  This can result in:  
  - Hanging requests when servers are slow or unresponsive  
  - Resource exhaustion due to accumulating open connections  
  - Potential denial-of-service vulnerabilities  

  Impact:  
  - Server or client resource leaks (Goroutines and sockets remain open)  
  - Application performance degradation or crashes  
  - Unreliable network calls affecting system stability  

  Vulnerable Example: 
  ```go
  client := &http.Client{} //Infinite timeout — can cause resource leaks

  Remediation:
  Always set a timeout when creating an `http.Client` to ensure that requests do not hang indefinitely.  
  ```go
  client := &http.Client{
      Timeout: time.Second * 10, //Set a timeout of 10 seconds
  }