### PR TITLE
checker: go_insecure_cookie

### DIFF
--- a/checkers/go/insecure_cookie.test.go
+++ b/checkers/go/insecure_cookie.test.go
@@ -1,0 +1,19 @@
+// <expect-error>
+http.SetCookie(&http.Cookie{
+    Name: "session",
+    Value: "123456",
+	Secure: false,
+})
+
+// <expect-error>
+http.SetCookie(&http.Cookie{
+	Name: "session",
+	Value: "123456",
+})
+
+// Safe - setting Secure to true
+http.SetCookie(&http.Cookie{
+	Name: "session",
+	Value: "123456",
+	Secure: true
+})

--- a/checkers/go/insecure_cookie.yml
+++ b/checkers/go/insecure_cookie.yml
@@ -1,0 +1,32 @@
+language: go
+name: go_insecure_cookie
+message: "Avoid using http.SetCookie to set cookies without the Secure flag to prevent insecure cookie handling."
+category: security
+severity: critical
+pattern: >
+  [
+    (call_expression
+      function: (selector_expression
+        operand: (identifier) @http
+        field: (field_identifier) @method
+        (#match? @http "^http$")
+        (#match? @method "^SetCookie$"))
+      arguments: (argument_list
+        (unary_expression
+          (composite_literal
+            (qualified_type
+              package: (package_identifier) @pkg
+              name: (type_identifier) @type
+              (#match? @pkg "^http$")
+              (#match? @type "^Cookie$"))
+            (literal_value) @cookie_body
+            (#not-match? @cookie_body ".*Secure.*true.*"))))) @go_insecure_cookie
+  ]
+exclude:  
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The Secure flag prevents cookies from being sent over an unencrypted connection. This helps
+  mitigate the risk. 


### PR DESCRIPTION

## Description
This PR adds a security check to detect usage of `http.SetCookie` without the `Secure` flag, ensuring cookies are transmitted only over HTTPS to prevent interception.

## Why This Matters  
- **Data Leakage:** Without the `Secure` flag, cookies can be transmitted over unencrypted connections, exposing sensitive information.  
- **Session Hijacking:** Attackers can intercept cookies over HTTP and hijack user sessions.  
- **Compliance:** Secure cookie handling is a requirement for many security standards and best practices.  

## Insecure Code Example  
```go
http.SetCookie(w, &http.Cookie{
  Name:  "session_id",
  Value: "xyz123", // No Secure flag
})
```

## Secure Code Example
```
http.SetCookie(w, &http.Cookie{
  Name:   "session_id",
  Value:  "xyz123",
  Secure: true, // Secure flag ensures cookie is sent only over HTTPS
})
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References
[secure_and_httponly_cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#secure_and_httponly_cookies)
