### PR TITLE
checker: go_jwt_hardcoded_signing_key

### DIFF
--- a/checkers/go/jwt_harcoded_signing_key.test.go
+++ b/checkers/go/jwt_harcoded_signing_key.test.go
@@ -1,0 +1,45 @@
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// CustomClaims defines custom JWT claims
+type CustomClaims struct {
+	Username string `json:"username"`
+	jwt.RegisteredClaims
+}
+
+func main() {
+	// Define claims
+	claims := CustomClaims{
+		Username: "user123",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)), // Token expires in 24 hours
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	insecureToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	//<expect-error> Hardcoding secrets is insecure
+	tokenStringInsecure, err := insecureToken.SignedString([]byte("secret"))
+	if err != nil {
+		log.Fatalf("Error signing token (insecure): %v", err)
+	}
+	fmt.Println("Insecure token:", tokenStringInsecure)
+
+	// Secure: Signing key from environment variable
+	secretKey := os.Getenv("SECRET") // 🔑 Get signing key securely
+	if secretKey == "" {
+		log.Fatal("Environment variable SECRET not set")
+	}
+
+	secureToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenStringSecure, err := secureToken.SignedString([]byte(secretKey))
+	if err != nil {
+		log.Fatalf("Error signing token (secure): %v", err)
+	}
+	fmt.Println("Secure token:", tokenStringSecure)
+}

--- a/checkers/go/jwt_harcoded_signing_key.yml
+++ b/checkers/go/jwt_harcoded_signing_key.yml
@@ -1,0 +1,52 @@
+language: go
+name: go_jwt_harcoded_signing_key
+message: "Avoid using
+  hardcoded signing key in JWT as it can be easily compromised."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+  (call_expression
+    function: (selector_expression
+      operand: (_) @token
+      field: (field_identifier) @method
+      (#eq? @method "SignedString")
+    )
+    arguments: (argument_list) @args
+    (#match? @args "\".*\"")
+  )
+  ) @go_jwt_harcoded_signing_key
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue  
+  Hardcoding signing keys in JWT tokens exposes them to potential source code leaks and compromises.  
+  If attackers obtain the key, they can forge valid tokens, bypassing authentication and authorization mechanisms.
+
+  Impact  
+  - Unauthorized access to protected resources  
+  - Token forgery and privilege escalation  
+  - Breach of sensitive data and user impersonation
+
+  Remediation
+  - Use a secure random key generator to create a strong signing key.
+  - Store the key securely, such as in a secure key management system.
+  - Rotate keys periodically to limit exposure in case of a breach.
+  - Use Environment Variables or Configuration Files to load the key dynamically.
+
+  Example
+  ```go
+  // Vulnerable: Hardcoded signing key
+  token := jwt.New(jwt.SigningMethodHS256)
+  tokenString, err := token.SignedString([]byte("my_secret_key"))
+
+  // Secure: Load signing key from environment variable
+  key := os.Getenv("JWT_SIGNING_KEY")
+  token := jwt.New(jwt.SigningMethodHS256)
+  tokenString, err := token.SignedString([]byte(key))
+  ```


### PR DESCRIPTION
## DEscription
This PR introduces a security check that flags the use of hardcoded JWT signing keys, which can be easily exposed and exploited. Developers are encouraged to load signing keys securely through environment variables or secret management solutions.

## Why This Matters  
- **Exposure Risk:** Hardcoded keys are prone to leaks through code sharing or version control.  
- **Token Forgery:** Attackers with access to the key can craft valid JWTs to bypass security.  
- **Privilege Escalation:** Unauthorized users can gain elevated privileges using forged tokens.  

## Insecure Code Example  
```go
import "github.com/golang-jwt/jwt"

func insecureJWT() {
  token := jwt.New(jwt.SigningMethodHS256)
  tokenString, err := token.SignedString([]byte("my_secret_key")) // Hardcoded key
  if err != nil {
    panic(err)
  }
  fmt.Println("Token:", tokenString)
}
```

## Secure Code Example
```
func secureJWT() {
  key := os.Getenv("JWT_SIGNING_KEY") //  Secure key retrieval
  if key == "" {
    panic("JWT_SIGNING_KEY not set")
  }

  token := jwt.New(jwt.SigningMethodHS256)
  tokenString, err := token.SignedString([]byte(key))
  if err != nil {
    panic(err)
  }
  fmt.Println("Secure Token:", tokenString)
}
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`