### PR TITLE
checker: go_jwt_none_algorithm

### DIFF
--- a/checkers/go/jwt_none_algorithm.test.go
+++ b/checkers/go/jwt_none_algorithm.test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// CustomClaims defines the JWT claims structure.
+type CustomClaims struct {
+	Username string `json:"username"`
+	jwt.RegisteredClaims
+}
+
+func main() {
+	// Create claims with username and expiration time
+	claims := CustomClaims{
+		Username: "example_user",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)), // Token expires in 1 hour
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "your-app",
+		},
+	}
+
+	// -------------------------
+	// Unsafe token creation (SigningMethodNone) - SHOULD NOT BE USED
+	// -------------------------
+	// <expect-error>
+	tokenNone := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+
+	// Attempting to sign with 'None' signature type is unsafe and should be avoided
+	// <expect-error>
+	ssNone, err := tokenNone.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		fmt.Println("Expected error (None Signature):", err)
+	} else {
+		fmt.Println("Unsafe Token (None Signature):", ssNone)
+	}
+
+	// -------------------------
+	// Safe token creation (HS256) - Recommended approach
+	// -------------------------
+	// Make sure the SECRET environment variable is set
+	secret := os.Getenv("SECRET")
+	if secret == "" {
+		fmt.Println("SECRET environment variable is not set.")
+		return
+	}
+
+	// Create a token using the HS256 signing method
+	tokenHS256 := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	// Sign the token with the provided secret
+	ssHS256, err := tokenHS256.SignedString([]byte(secret))
+	if err != nil {
+		fmt.Println("Error signing token with HS256:", err)
+		return
+	}
+
+	// Safe signed token output
+	fmt.Println("Safe Token (HS256):", ssHS256)
+}

--- a/checkers/go/jwt_none_algorithm.yml
+++ b/checkers/go/jwt_none_algorithm.yml
@@ -1,0 +1,38 @@
+language: go
+name: go_jwt_none_algorithm
+message: "Avoid using the 'none' algorithm in JWT as it disables signature verification and exposes the application to token forgery attacks."
+category: security
+severity: critical
+pattern: >
+  [
+    (selector_expression
+  operand: (identifier) @jwt
+  field: (field_identifier) @method
+  (#eq? @jwt "jwt")
+  (#match? @method "^(SigningMethodNone|UnsafeAllowNoneSignatureType)$")) @go_jwt_none_algorithm
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue: 
+  The 'none' algorithm in JWT disables signature verification, allowing attackers to forge tokens and gain unauthorized access.  
+  This vulnerability has been exploited in the past (e.g., [JWT 'none' algorithm vulnerability - Auth0 Blog](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/)) and poses a serious security risk.
+
+  Impact: 
+  If an attacker sends a JWT with the 'none' algorithm, the server may accept it as valid, compromising authentication and authorization mechanisms.
+
+  Remediation:  
+  - Do not use `SigningMethodNone` or `UnsafeAllowNoneSignatureType`.  
+  - Use secure algorithms like `HS256` (HMAC), `RS256` (RSA), or `ES256` (ECDSA).  
+  - Always validate and specify the expected signing method when parsing JWTs:
+    ```go
+    token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+      if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+        return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+      }
+      return []byte(os.Getenv("SECRET")), nil
+    })
+    ```


### PR DESCRIPTION

## Description
This PR introduces a security check that detects and prevents the usage of the `'none'` algorithm in JWT. The `'none'` algorithm disables signature verification, exposing applications to severe security vulnerabilities like token forgery and unauthorized access.

## Why This Matters  
- **Bypass Protection:** Attackers can send tokens with `'none'` as the algorithm, tricking applications into accepting unsigned tokens.  
- **Security Breach Risk:** Vulnerabilities like this have been actively exploited in the past. ([Auth0 Blog on JWT Vulnerabilities](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/))  
- **Compliance:** Prevents usage of insecure JWT configurations, meeting security best practices and audit requirements.  

##  Insecure Example  
```go
import "github.com/golang-jwt/jwt"

func unsafeJWT() {
  token := jwt.New(jwt.SigningMethodNone) // Insecure: no signature verification
  _ = token
}
```

## Secure Example
```
func safeJWT(tokenString string) {
  token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
    // Enforce specific signing methods
    if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
      return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
    }
    return []byte(os.Getenv("SECRET")), nil
  })

  if err != nil {
    fmt.Printf("Token parsing error: %v\n", err)
  } else if token.Valid {
    fmt.Println("Valid token")
  } else {
    fmt.Println("Invalid token")
  }
}
```

## Exclusions
`test/**,*_test.go,tests/**,__tests__/**`

## References
[JWT Vulnerabilities](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/)