### PR TITLE
checker: go_md5_weak_hash

### DIFF
--- a/checkers/go/md5_weak_hash.test.go
+++ b/checkers/go/md5_weak_hash.test.go
@@ -1,0 +1,34 @@
+import (
+	// <expect-error> Weak hash function used
+	"crypto/md5"    // UNSAFE: Weak hash function
+	"crypto/sha256" // SAFE: Strong hash function
+	"encoding/hex"
+	"fmt"
+)
+
+func testWeakHash(data string) {
+	hasher := md5.New() // MD5 is considered cryptographically broken
+
+	_, err := hasher.Write([]byte(data))
+	if err != nil {
+		fmt.Println("Error writing data to MD5 hasher:", err)
+		return
+	}
+
+	hashBytes := hasher.Sum(nil)
+	fmt.Printf("MD5 Hash (Weak): %s\n", hex.EncodeToString(hashBytes))
+}
+
+func testSafeHash(data string) {
+	// Safe - using SHA256
+	hasher := sha256.New()
+
+	_, err := hasher.Write([]byte(data))
+	if err != nil {
+		fmt.Println("Error writing data to SHA256 hasher:", err)
+		return
+	}
+
+	hashBytes := hasher.Sum(nil)
+	fmt.Printf("SHA256 Hash (Secure): %s\n", hex.EncodeToString(hashBytes))
+}

--- a/checkers/go/md5_weak_hash.yml
+++ b/checkers/go/md5_weak_hash.yml
@@ -1,0 +1,42 @@
+language: go
+name: go_md5_weak_hash
+message: "Avoid using MD5 to hash sensitive data as it is vulnerable to collision attacks. Use SHA-256 or stronger algorithms instead."
+category: security
+severity: critical
+pattern: >
+  [
+    (import_spec
+      path: (interpreted_string_literal) @import
+      (#eq? @import "\"crypto/md5\""))
+  ] @go_md5_weak_hash
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:  
+  MD5 is a cryptographically weak hashing algorithm that is vulnerable to collision and preimage attacks, making it unsuitable for hashing sensitive data such as passwords, tokens, or digital signatures. Attackers can exploit these weaknesses to forge data integrity checks or bypass security controls.
+
+  Impact:  
+  Using MD5 for security purposes can lead to data tampering, authentication bypass, and compromise of system integrity.
+
+  Remediation:  
+  - Do not use MD5 for any cryptographic or security-related purposes.  
+  - Recommended alternatives: Use SHA-256 (`crypto/sha256`), SHA-512 (`crypto/sha512`), or modern password hashing algorithms like bcrypt, scrypt, or Argon2 for secure hashing.  
+  -  Example using SHA-256:
+    ```go
+    import (
+      "crypto/sha256"
+      "encoding/hex"
+      "fmt"
+    )
+
+    func main() {
+      data := "example_data"
+      hasher := sha256.New()
+      hasher.Write([]byte(data))
+      hashBytes := hasher.Sum(nil)
+      fmt.Printf("SHA256 Hash: %s\n", hex.EncodeToString(hashBytes))
+    }
+    ``` 


### PR DESCRIPTION
## Description  
This PR adds a checker that detects imports of the `crypto/md5` package, highlighting the use of the weak MD5 hashing algorithm. MD5 is susceptible to collision attacks, making it unsuitable for hashing sensitive data.

---

## Why is this a problem?  
- **Collision Vulnerability:** Attackers can generate different inputs with the same hash, compromising data integrity.  
- **Preimage Attacks:** It's feasible to reverse-engineer the hash back to its original input.  
- **Compliance Issues:** Many security standards (e.g., PCI-DSS, NIST) prohibit the use of MD5 in security-sensitive contexts.  

---

## Insecure Example  
```go
import (
  "crypto/md5"
  "fmt"
)

func main() {
  data := []byte("sensitive_data")
  hash := md5.Sum(data) // Vulnerable to collisions
  fmt.Printf("MD5 Hash: %x\n", hash)
}
```

## Exclusions
`test/**,*_test.go,tests/**,__tests__/**`

## Reference
[NIST Hashing Policy](https://csrc.nist.gov/projects/hash-functions)
