### PR TITLE
checker: go_missing_error_file

### DIFF
--- a/checkers/go/missing_error_file_open.test.go
+++ b/checkers/go/missing_error_file_open.test.go
@@ -1,0 +1,36 @@
+import (
+	"fmt"
+	"os"
+)
+
+func badFileHandling() error {
+	// <expect-error> error not captured
+	f, _ := os.Open("data.txt")
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+
+	data := make([]byte, 100)
+	_, err = f.Read(data)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+	return nil
+}
+
+func goodFileHandling() error {
+	// Safe err is captured
+	f, err := os.Open("data.txt") 
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close() 
+	data := make([]byte, 100)
+	_, err = f.Read(data)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return nil
+}

--- a/checkers/go/missing_error_file_open.yml
+++ b/checkers/go/missing_error_file_open.yml
@@ -1,0 +1,47 @@
+language: go
+name: go_missing_error_file_open
+message: "Failing to check errors returned by os.Open"
+category: best-practice
+severity: warning
+pattern: >
+  (
+    (short_var_declaration
+      left: (expression_list
+        (identifier) @file_var 
+        (identifier) @err_var)
+      right: (expression_list
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @os
+            field: (field_identifier) @open_func))
+    ) @body
+
+  (#eq? @os "os")
+  (#match? @open_func "^Open")
+  (#eq? @err_var "_")
+  )) @go_missing_error_file_open
+
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  In Go, functions like `os.Open` return two values: a file handle (`*os.File`) and an error. The error indicates whether the file was successfully opened, with common failure cases including the file not existing, insufficient permissions, or invalid file paths. 
+  Ignoring this error by assigning it to `_` can lead to serious issues.
+
+  Impact:
+  - Nil Pointer Dereferences: If the file fails to open, the returned `*os.File` will be `nil`. Attempting to use this `nil` file handle (e.g., calling `f.Read()`) will cause a runtime panic, crashing the program unexpectedly.
+  - Silent Failures: Without checking the error, the program may proceed with invalid assumptions, such as assuming the file was opened successfully, leading to incorrect behavior like processing empty data or skipping critical configuration.
+  - Security Risks: If the file contains security-critical data (e.g., a policy or credentials file), ignoring the error might allow the program to run with unsafe defaults, potentially exposing vulnerabilities.
+
+  Remediation:
+  ```go
+  f, err := os.Open("config.txt") 
+  if err != nil {   // Check the error
+    fmt.Println("Failed to open file")
+  }
+  data, _ := ioutil.ReadAll(f) 
+  fmt.Println(string(data))
+  


### PR DESCRIPTION
## Description  
This PR introduces a checker that detects when the error returned by `os.Open` is ignored. Failing to handle this error can lead to runtime panics, silent failures, and potential security vulnerabilities.

## Detection Logic  
The checker flags cases where:  
- `os.Open` or related methods are called.  
- The returned error is assigned to `_` (ignored).  

## Why is this a problem?  
- **Nil Pointer Dereference:** Using the file handle without verifying the error can cause a panic if the file didn't open.  
- **Silent Failures:** Ignoring the error may lead to incorrect assumptions, such as processing nonexistent files.  
- **Security Concerns:** Files containing critical configurations or credentials may be bypassed if errors are ignored.  

---

## Insecure Example  
```go
f, _ := os.Open("config.txt") // Error ignored
data, _ := ioutil.ReadAll(f)
fmt.Println(string(data))

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References

[os pkg](https://pkg.go.dev/os)
