### PR TITLE
checker: go_net_bind_all_interfaces

### DIFF
--- a/checkers/go/net_bind_all_interfaces.test.go
+++ b/checkers/go/net_bind_all_interfaces.test.go
@@ -1,0 +1,26 @@
+func bind_all() {
+	// <expect-error> Bind to all interfaces
+	l, err := net.Listen("tcp", ":2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+}
+
+func bind_all2() {
+	// <expect-error> Bind to all interfaces
+	l, err := net.Listen("tcp", "0.0.0.0:2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+}
+
+func bind_all3() {
+	// Safe localhost
+	l, err := net.Listen("tcp", "127.0.0.1:2000")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer l.Close()
+}

--- a/checkers/go/net_bind_all_interfaces.yml
+++ b/checkers/go/net_bind_all_interfaces.yml
@@ -1,0 +1,48 @@
+language: go
+name: go_net_bind_all_interfaces
+message: "Avoid binding to all network interfaces to listen for incoming connections."
+category: security
+severity: warning
+pattern: >
+  (
+    (call_expression
+      function: (selector_expression
+        operand: (identifier) @_pkg
+        field: (field_identifier) @_func
+      )
+      arguments: (argument_list
+        (interpreted_string_literal) @protocol
+        (interpreted_string_literal) @address
+      )
+    )
+    (#eq? @_pkg "net")
+    (#eq? @_func "Listen")
+    (#match? @address "\"(0\\.0\\.0\\.0.*|:.*)\"")
+  )
+  @go_net_bind_all_interfaces
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Binding to all network interfaces (`0.0.0.0`) can expose your application to external threats, 
+  increasing the risk of unauthorized access and attacks. 
+
+  Instead, consider binding to a specific IP address or `localhost (127.0.0.1)` if external access is not required.
+
+  Example of Insecure Code:
+  ```go
+  ln, err := net.Listen("tcp", "0.0.0.0:8080")
+  if err != nil {
+      log.Fatal(err)
+  }
+  defer ln.Close()
+
+  Remediation:
+  ```go
+  ln, err := net.Listen("tcp", "127.0.0.1:8080") // Bind to localhost
+  if err != nil {
+      log.Fatal(err)
+  }
+  defer ln.Close()


### PR DESCRIPTION
## Description  
This PR adds a Go checker that detects when applications bind to all network interfaces (`0.0.0.0` or `:port`) using `net.Listen`. Binding to all interfaces can unintentionally expose services to external networks, increasing the risk of unauthorized access.

## Detection Logic  
The checker flags:  
- Calls to `net.Listen` with addresses like `"0.0.0.0:port"` or `":port"`.

## Why is this a problem?  
- **Unrestricted Access:** Exposing services on all interfaces can allow external attackers to reach internal services.  
- **Attack Surface Expansion:** Services unintentionally exposed can be targeted by port scanning tools.  
- **Compliance Concerns:** Certain regulations require limiting network exposure of sensitive services.  

## Remediation Steps  
### **Secure Approach:** Bind to a specific interface (e.g., `127.0.0.1`)  
If external access is not required, bind to `localhost`:  
```go
package main

import (
  "log"
  "net"
)

func main() {
  ln, err := net.Listen("tcp", "127.0.0.1:8080") // Secure: Bind to localhost
  if err != nil {
    log.Fatal(err)
  }
  defer ln.Close()
}
```

## Exclusion

`test/**,*_test.rb,tests/**,__tests__/**`
