### PR TITLE
checker: go_os_create_file_default_permission

### DIFF
--- a/checkers/go/os_create_file_default_permission.test.go
+++ b/checkers/go/os_create_file_default_permission.test.go
@@ -1,0 +1,26 @@
+import (
+	"fmt"
+	"os"
+)
+
+func test() {
+	fileName := "example.txt"
+
+	// <expect-error> os.Create is called (which uses default file permissions)
+	file, err := os.Create(fileName)
+	if err != nil {
+		fmt.Println("Error creating file:", err)
+		return
+	}
+	defer file.Close()
+	fmt.Println("File created with default permissions (potential security risk).")
+
+	// Safe alternative using os.OpenFile with explicit permissions (0600)
+	file, err = os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		fmt.Println("Error creating file securely:", err)
+		return
+	}
+	defer file.Close()
+	fmt.Println("File created securely with 0600 permissions.")
+}

--- a/checkers/go/os_create_file_default_permission.yml
+++ b/checkers/go/os_create_file_default_permission.yml
@@ -1,0 +1,54 @@
+language: go
+name: go_os_create_file_default_permission
+message: "Avoid creating files with default permissions to prevent unauthorized access."
+category: security
+severity: critical
+pattern: >
+  [
+    (
+  (short_var_declaration
+    left: (expression_list 
+      (identifier) @file_var 
+      (identifier) @err_var)
+    right: (expression_list
+      (call_expression
+        function: (selector_expression
+          operand: (identifier) @os_pkg
+          field: (field_identifier) @create_method
+        )
+        arguments: (argument_list
+          (identifier) @filename
+        )
+      )
+    )
+    (#eq? @os_pkg "os")
+    (#eq? @create_method "Create")
+  )
+  ) @go_os_create_file_default_permission
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Calling `os.Create()` creates a file with default permissions (`0666`), which may allow unintended read and write access to other users on the system.
+
+  Instead, explicitly set file permissions using `os.OpenFile()` to prevent unauthorized access.
+
+  Insecure Code:
+  ```go
+  file, err := os.Create("example.txt") // Creates file with default permissions (0666)
+  if err != nil {
+      log.Fatal(err)
+  }
+  defer file.Close()
+
+  Remediation:
+  ```go
+  file, err := os.OpenFile("example.txt", os.O_CREATE|os.O_WRONLY, 0600) // Set file permissions to 0600
+  if err != nil {
+      log.Fatal(err)
+  }
+  defer file.Close()
+  ```


### PR DESCRIPTION
## Description  
This PR introduces a Go checker that detects the usage of `os.Create` for file creation without specifying explicit permissions. By default, `os.Create` sets file permissions to `0666`, which may expose the file to unauthorized access.

## Detection Logic  
The checker flags:  
- Calls to `os.Create()` that do not define explicit file permissions.  

## Why is this a problem?  
- **Unintended Access:** Default permissions (`0666`) may allow other system users to read or write sensitive files.  
- **Data Integrity Risk:** Files created with overly permissive settings can be altered by unauthorized users.  
- **Compliance Issues:** Certain standards require explicit permission management for sensitive files.  

## Remediation Steps  
### *Secure Alternative: Use `os.OpenFile` with Explicit Permissions**  
Instead of using `os.Create`, use `os.OpenFile` and define proper permissions (e.g., `0600` for read/write by the owner only):  
```go
package main

import (
  "log"
  "os"
)

func main() {
  file, err := os.OpenFile("example.txt", os.O_CREATE|os.O_WRONLY, 0600) // Secure permissions
  if err != nil {
    log.Fatal(err)
  }
  defer file.Close()
}
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References

[OWASP Access control cheatsheet](https://owasp.deteact.com/cheat/cheatsheets/Access_Control_Cheat_Sheet.html)
