### PR TITLE
checker: go_postgres_config_raw_passwd

### DIFF
--- a/checkers/go/postgres_config_raw_passwd.test.go
+++ b/checkers/go/postgres_config_raw_passwd.test.go
@@ -1,0 +1,33 @@
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-pg/pg/v10"
+)
+
+func true() {
+	// Insecure: Hardcoded credentials (Security Risk)
+	// <expect-error>
+	optsInsecure := &pg.Options{
+		User:     "myuser",
+		Password: "hardcodedPassword123", //Hardcoded password
+		Database: "mydb",
+	}
+
+	fmt.Println("Insecure PG Options:", optsInsecure)
+
+	//Secure: Use environment variables for credentials
+	optsSecure := &pg.Options{
+		User:     "myuser",
+		Password: os.Getenv("PG_PASSWORD"), // Fetch password securely from environment variable
+		Database: "mydb",
+	}
+
+	// Ensure environment variable is set
+	if optsSecure.Password == "" {
+		fmt.Println("Error: PG_PASSWORD environment variable is not set")
+		return
+	}
+
+	fmt.Println("Secure PG Options:", optsSecure)
+}

--- a/checkers/go/postgres_config_raw_passwd.yml
+++ b/checkers/go/postgres_config_raw_passwd.yml
@@ -1,0 +1,43 @@
+language: go
+name: go_postgres_config_raw_passwd
+message: "Do not hardcode PostgreSQL passwords in the source code."
+category: security
+severity: critical
+pattern: >
+  [
+    (composite_literal
+  type: (qualified_type
+    package: (package_identifier) @pkg
+    name: (type_identifier) @type
+    (#match? @pkg "^pg$")
+    (#match? @type "^Options$"))
+  body: (literal_value
+    (keyed_element
+      (literal_element) @field
+      (literal_element 
+        (interpreted_string_literal) @value)
+      (#match? @field "^Password$")))) @go_postgres_config_raw_passwd
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Hardcoding PostgreSQL passwords in source code exposes sensitive information, 
+  increasing the risk of unauthorized access, especially if the code is stored 
+  in version control systems.
+
+  Why this is a problem:
+  - Compromised source code leads to database breaches.
+  - Credentials in repositories can be scanned and exploited by attackers.
+
+  Remediation Steps:
+  1. Use environment variables to manage sensitive data:
+     ```go
+     import "os"
+
+     options.Password = os.Getenv("PG_PASSWORD")
+     ```
+  2. Use a secure secret management service (e.g., HashiCorp Vault, AWS Secrets Manager).
+  3. Ensure `.env` files and other sensitive configurations are excluded from version control via `.gitignore`.


### PR DESCRIPTION
## Description  
This PR introduces a Go checker that detects hardcoded PostgreSQL passwords within `pg.Options` structs.

## Detection Logic  
The checker flags:  
- Composite literals of type `pg.Options` containing a `Password` field assigned with a hardcoded string.  

## Why is this a problem?  
- **Credential Exposure:** Hardcoded passwords make databases vulnerable to unauthorized access.  
- **Version Control Risks:** Secrets in code can be accidentally pushed to repositories.  
- **Operational Risks:** Hardcoded credentials hinder secure credential rotation practices.  

## Remediation Steps  
### **Preferred Solution: Use Environment Variables**  
Replace hardcoded passwords with environment variable lookups:  
```go
import (
  "os"
  "github.com/go-pg/pg/v10"
)

func main() {
  options := &pg.Options{
    User:     "pguser",
    Password: os.Getenv("PG_PASSWORD"), // Secure alternative
    Addr:     "localhost:5432",
    Database: "exampledb",
  }
}
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References

[OWASP Secret Management CheatSheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
