### PR TITLE
checker: go_postgres_conn_raw_passwd

### DIFF
--- a/checkers/go/postgres_conn_raw_passwd.test.go
+++ b/checkers/go/postgres_conn_raw_passwd.test.go
@@ -1,0 +1,41 @@
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+)
+
+func test() {
+	// Insecure: Hardcoded password - Vulnerable to credential leaks
+	// <expect-error>
+	dbInsecure, err := sql.Open("postgres", "postgres://myuser:hardcodedPassword456@localhost:5432/mydb")
+	if err != nil {
+		log.Fatalf("Failed to connect (insecure): %v", err)
+	}
+	defer dbInsecure.Close()
+
+	fmt.Println("Insecure connection established (not recommended).")
+
+	// Secure: Use environment variables to avoid hardcoding sensitive data
+	user := os.Getenv("PG_USER")
+	passwd := os.Getenv("PG_PASSWORD")
+	host := os.Getenv("PG_HOST")
+	port := os.Getenv("PG_PORT")
+	name := os.Getenv("PG_DBNAME")
+
+	// Check if essential environment variables are set
+	if user == "" || passwd == "" || host == "" || port == "" || name == "" {
+		log.Fatal("One or more environment variables (PG_USER, PG_PASSWORD, PG_HOST, PG_PORT, PG_DBNAME) are missing.")
+	}
+
+	connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, passwd, host, port, name)
+	dbSecure, err := sql.Open("postgres", connStr)
+	if err != nil {
+		log.Fatalf("Failed to connect (secure): %v", err)
+	}
+	defer dbSecure.Close()
+
+	fmt.Println("Secure connection established using environment variables.")
+}

--- a/checkers/go/postgres_conn_raw_passwd.yml
+++ b/checkers/go/postgres_conn_raw_passwd.yml
@@ -1,0 +1,56 @@
+language: go
+name: go_postgres_conn_raw_passwd
+message: "Do not hardcode PostgreSQL passwords in the source code."
+category: security
+severity: critical
+pattern: >
+  [
+    (call_expression
+  function: (selector_expression
+    operand: (identifier) @sql
+    field: (field_identifier) @method
+    (#match? @sql "^sql$")
+    (#match? @method "^Open$"))
+  arguments: (argument_list 
+    (_) @driver
+    (interpreted_string_literal) @conn_string
+    (#match? @conn_string "^\"postgres://.*:.*@.*\"$"))) @go_postgres_conn_raw_passwd
+  ]
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Hardcoding PostgreSQL connection strings with passwords in the source code is a critical security risk. 
+  It exposes sensitive credentials, making applications vulnerable to unauthorized access, especially 
+  if the code is shared or stored in version control systems.
+
+  Why this is a problem:
+  - Attackers can easily extract hardcoded credentials from repositories or compiled binaries.
+  - Credentials in source code can lead to database breaches and data theft.
+
+  Remediation:
+  - Use environment variables or configuration files to store sensitive information.
+  - Implement secure credential management practices, such as using secrets management tools.
+  - Rotate passwords regularly and avoid storing them in plaintext.
+  Secure Example:
+  ```go
+    user := os.Getenv("PG_USER")
+    passwd := os.Getenv("PG_PASSWORD")
+    host := os.Getenv("PG_HOST")
+    port := os.Getenv("PG_PORT")
+    name := os.Getenv("PG_DBNAME")
+
+    // Check if essential environment variables are set
+    if user == "" || passwd == "" || host == "" || port == "" || name == "" {
+      log.Fatal("One or more environment variables (PG_USER, PG_PASSWORD, PG_HOST, PG_PORT, PG_DBNAME) are missing.")
+    }
+
+    connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, passwd, host, port, name)
+    dbSecure, err := sql.Open("postgres", connStr)
+    if err != nil {
+      log.Fatalf("Failed to connect (secure): %v", err)
+    }
+    defer dbSecure.Close()
+    ```


### PR DESCRIPTION
## Description  
This PR adds a Go checker that detects hardcoded PostgreSQL connection strings containing plaintext passwords.

## Detection Logic  
The checker flags the following pattern:  
- Calls to `sql.Open` where the connection string includes a hardcoded PostgreSQL URL with embedded credentials (e.g., `"postgres://user:password@host"`).

## Why is this a problem?  
- **Credential Exposure:** Hardcoded passwords can be easily extracted from source code, compromising databases.  
- **Version Control Risks:** Sensitive information might be exposed if the code is shared or pushed to repositories.  
- **Operational Security:** Hardcoded secrets hinder proper credential rotation and secure management practices.

## Remediation Steps  
### **Preferred Solution: Use Environment Variables**  
Avoid hardcoding credentials. Use environment variables instead:  
```go
import (
  "database/sql"
  "fmt"
  "log"
  "os"

  _ "github.com/lib/pq"
)

func main() {
  user := os.Getenv("PG_USER")
  passwd := os.Getenv("PG_PASSWORD")
  host := os.Getenv("PG_HOST")
  port := os.Getenv("PG_PORT")
  name := os.Getenv("PG_DBNAME")

  // Validate environment variables
  if user == "" || passwd == "" || host == "" || port == "" || name == "" {
    log.Fatal("Missing environment variables (PG_USER, PG_PASSWORD, PG_HOST, PG_PORT, PG_DBNAME).")
  }

  connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s", user, passwd, host, port, name)
  dbSecure, err := sql.Open("postgres", connStr)
  if err != nil {
    log.Fatalf("Secure connection failed: %v", err)
  }
  defer dbSecure.Close()
}
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References

[OWASP Secrets Management CheatSheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
