### PR TITLE
checker: go_pprof_endpoint_automatic_exposure

### DIFF
--- a/checkers/go/pprof_endpoint_automatic_exposure.test.go
+++ b/checkers/go/pprof_endpoint_automatic_exposure.test.go
@@ -1,0 +1,51 @@
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"runtime/pprof"
+	"time"
+	
+	// Insecure: Automatically exposes pprof endpoints over HTTP, allowing potential attackers to access profiling data.
+	// <expect-error> automatic exposure of pprof endpoint
+	_ "net/http/pprof"
+)
+
+func main() {
+	// Insecure Example: 
+	// Importing "net/http/pprof" without proper authentication exposes profiling endpoints (e.g., /debug/pprof/)
+	// to anyone with network access. This can leak sensitive information like memory usage and stack traces.
+	fmt.Println("Insecure pprof endpoint automatically exposed (not recommended).")
+
+	// Secure Example:
+	// Use "runtime/pprof" to manually control profiling without exposing HTTP endpoints.
+	
+	// Create a CPU profile file
+	cpuProfile, err := os.Create("cpu_profile.prof")
+	if err != nil {
+		log.Fatalf("Could not create CPU profile: %v", err)
+	}
+	defer cpuProfile.Close()
+
+	// Start CPU profiling
+	if err := pprof.StartCPUProfile(cpuProfile); err != nil {
+		log.Fatalf("Could not start CPU profile: %v", err)
+	}
+	fmt.Println("CPU profiling started...")
+
+	// Simulate workload for profiling
+	doWork()
+
+	// Stop CPU profiling
+	pprof.StopCPUProfile()
+	fmt.Println("CPU profiling stopped. Profile saved to cpu_profile.prof")
+}
+
+func doWork() {
+	// Simulated CPU-intensive task
+	start := time.Now()
+	for i := 0; i < 5000000; i++ {
+		_ = i * i
+	}
+	fmt.Printf("Work completed in %v\n", time.Since(start))
+}

--- a/checkers/go/pprof_endpoint_automatic_exposure.yml
+++ b/checkers/go/pprof_endpoint_automatic_exposure.yml
@@ -1,0 +1,63 @@
+language: go
+name: go_pprof_endpoint_automatic_exposure
+message: "Avoid exposing net/http/pprof; it automatically exposes the /debug/pprof endpoint."
+category: security
+severity: warning
+pattern: >
+  (
+    (import_spec
+      name: (blank_identifier)
+      path: (interpreted_string_literal) @import_path
+      (#match? @import_path "\"net/http/pprof\"")
+    )
+  )
+  @go_pprof_endpoint_automatic_exposure
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Importing the net/http/pprof package automatically registers debugging and profiling endpoints 
+  under /debug/pprof. While useful for development, exposing these endpoints in production can lead 
+  to information disclosure, allowing attackers to access application internals like goroutine dumps, 
+  heap profiles, and CPU usage.
+
+  Why this is a problem:
+  - Exposes sensitive runtime information that can aid attackers in crafting exploits.
+  - Can reveal performance bottlenecks and resource usage details to unauthorized users.
+
+  Remediation Steps:
+  1. **Remove net/http/pprof in production environments:**  
+     Use build tags to include pprof only during development.
+     ```go
+     //go:build debug
+     import _ "net/http/pprof"
+     ```
+  2. Secure the pprof endpoint if needed in production:  
+     Restrict access using middleware, IP whitelisting, or authentication.
+     ```go
+     import (
+       "net/http"
+       "net/http/pprof"
+     )
+
+     func registerPprofRoutes(mux *http.ServeMux) {
+       mux.HandleFunc("/debug/pprof/", pprof.Index)
+     }
+
+     // Wrap with basic auth (for example purposes only)
+     ```
+  3. Use runtime/pprof for manual profiling without exposing HTTP endpoints:
+     ```go
+     import (
+       "os"
+       "runtime/pprof"
+     )
+
+     func main() {
+       f, _ := os.Create("cpu.prof")
+       pprof.StartCPUProfile(f)
+       defer pprof.StopCPUProfile()
+     }
+     ```


### PR DESCRIPTION
## Description  
This PR introduces a Go checker that detects imports of the `net/http/pprof` package, which automatically exposes the `/debug/pprof` endpoint.

## Detection Logic  
The checker flags instances where the `"net/http/pprof"` package is imported, even with a blank identifier.

## Why is this a problem?  
- **Information Disclosure:** Exposes runtime details (goroutines, heap, CPU profiles) that attackers can exploit.  
- **Production Risk:** Accessible endpoints can leak sensitive operational data.  
- **Security Concern:** Profiling information should not be publicly exposed in production environments.

## Remediation Steps  
### **Option 1: Remove in Production**  
Use build tags to include `pprof` only in non-production builds:  
```go
//go:build debug
import _ "net/http/pprof"
```
## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References
[pprof security considerations](https://github.com/golang/go/issues/22085)
