### PR TITLE
checker: go_math_rand

### DIFF
--- a/checkers/go/math_rand.test.go
+++ b/checkers/go/math_rand.test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	// <expect-error> import "math/rand"
+	"math/rand"
+	"math/big"
+	"time"
+)
+
+func unsafeRandomExample(n int) {
+	// -------------------------
+	// UNSAFE: Using math/rand for security-sensitive randomness
+	// -------------------------
+	// Weak random number generator
+	mathrand.Seed(time.Now().UnixNano())
+	randomNumber := rand.Intn(n)     // Not suitable for cryptographic purposes
+	fmt.Printf("Unsafe random number (math/rand): %d\n", randomNumber)
+}
+
+func safeRandomExample(n int) {
+	// -------------------------
+	// SAFE: Using crypto/rand for secure randomness
+	// -------------------------
+	// crypto/rand provides cryptographically secure random numbers
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(int64(n)))
+	if err != nil {
+		fmt.Println("Error generating secure random number:", err)
+		return
+	}
+	fmt.Printf("Safe random number (crypto/rand): %d\n", randomNumber.Int64())
+}

--- a/checkers/go/math_rand.yml
+++ b/checkers/go/math_rand.yml
@@ -1,0 +1,44 @@
+language: go
+name: go_math_rand
+message: "Avoid using the math/rand package for cryptographic operations. Use crypto/rand for secure randomness."
+category: security
+severity: critical
+pattern: >
+  [
+    (import_spec
+      path: (interpreted_string_literal) @import
+      (#eq? @import "\"math/rand\""))
+  ] @go_math_rand
+exclude:
+  - "test/**"
+  - "*_test.go"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue: 
+  The `math/rand` package generates deterministic pseudo-random numbers and is **not suitable** for cryptographic use cases such as token generation, password creation, or secure key generation. 
+  Predictable random values can lead to security vulnerabilities.
+
+  Impact:  
+  Attackers can exploit predictable randomness to guess tokens or keys, compromising authentication and data integrity.
+
+  Remediation: 
+  - Replace `math/rand` with `crypto/rand` for all security-sensitive randomness.  
+  - Example of secure random number generation:
+    ```go
+    import (
+      "crypto/rand"
+      "fmt"
+      "math/big"
+    )
+
+    func main() {
+      n := int64(100)
+      randomNumber, err := rand.Int(rand.Reader, big.NewInt(n))
+      if err != nil {
+        fmt.Println("Error generating secure random number:", err)
+        return
+      }
+      fmt.Println("Secure random number:", randomNumber.Int64())
+    }
+    ```


### PR DESCRIPTION
## Description  
This PR adds a Go checker that detects the use of the `math/rand` package for cryptographic operations, which is insecure.

## Detection Logic  
The checker flags instances where the `"math/rand"` package is imported.

## Why is this an issue?  
- **Deterministic Output:** `math/rand` produces predictable random numbers.  
- **Security Risk:** Predictable randomness can lead to token and key guessing.  
- **Not Meant for Crypto:** The Go documentation advises against using `math/rand` for security purposes.

## Recommended Remediation  
**Use `crypto/rand` for cryptographic operations:**  
- Securely generate random numbers using `crypto/rand.Int`.  
- Use `rand.Reader` for cryptographically secure randomness.  

## Example Fix  
```go
import (
  "crypto/rand"
  "fmt"
  "math/big"
)

func main() {
  n := int64(100)
  randomNumber, err := rand.Int(rand.Reader, big.NewInt(n))
  if err != nil {
    fmt.Println("Error generating secure random number:", err)
    return
  }
  fmt.Println("Secure random number:", randomNumber.Int64())
}
```

## Exclusions
`test/**,*_test.rb,tests/**,__tests__/**`

## References
[math/rand: Deterministic random by default is dangerous](https://github.com/golang/go/issues/11871)
