### PR TITLE
checker: ruby_dsa_weak_crypto

### DIFF
--- a/checkers/ruby/dsa_weak_crypto.test.rb
+++ b/checkers/ruby/dsa_weak_crypto.test.rb
@@ -1,0 +1,14 @@
+require 'openssl'
+require 'base64'
+require 'bcrypt'
+
+def generate_dsa_key
+  # <expect-error> Use of DSA key (not recommended)
+  dsa = OpenSSL::PKey::DSA.new(1024)
+  dsa
+end
+
+# Safe - Hashing a password securely using bcrypt
+def hash_password(password)
+  BCrypt::Password.create(password) # Automatically generates a salt
+end

--- a/checkers/ruby/dsa_weak_crypto.yml
+++ b/checkers/ruby/dsa_weak_crypto.yml
@@ -1,0 +1,53 @@
+language: ruby
+name: ruby_dsa_weak_crypto
+message: "Avoid using DSA for cryptographic operations; it is outdated and insecure."
+category: security
+severity: critical
+pattern: >
+  (scope_resolution
+  scope: (scope_resolution
+    scope: (constant) @openssl (#eq? @openssl "OpenSSL")
+    name: (constant) @pkey (#eq? @pkey "PKey"))
+  name: (constant) @dsa (#eq? @dsa "DSA")) @ruby_dsa_weak_crypto
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  DSA (Digital Signature Algorithm) is considered weak due to its reliance on small key sizes and vulnerability 
+  to attacks, especially when poor random number generation is used. It is no longer recommended for cryptographic 
+  operations.
+
+  Why is this a problem?
+  - DSA with small key sizes (1024-bit) is vulnerable to brute-force attacks.
+  - Poor randomness in DSA signatures can lead to private key leaks.
+  - Modern security standards recommend stronger alternatives.
+
+  Remediation:
+  - Instead of DSA, use BCrypt for securely hashing passwords.
+  - If encryption is needed, use AES-256-GCM.
+
+  Example Fix:
+  ```ruby
+  require 'bcrypt'
+
+  # Weak DSA (Avoid)
+  require 'openssl'
+  dsa = OpenSSL::PKey::DSA.new(1024)  # Weak & insecure
+
+  # Secure BCrypt Alternative (for password hashing)
+  password = "SecurePassword123"
+  hashed_password = BCrypt::Password.create(password)
+  puts "BCrypt Hash: #{hashed_password}"
+
+  # Secure AES Alternative (for encryption)
+  require 'openssl'
+  cipher = OpenSSL::Cipher.new('aes-256-gcm')
+  cipher.encrypt
+  key = cipher.random_key
+  iv = cipher.random_iv
+  encrypted = cipher.update("Sensitive Data") + cipher.final
+  puts "AES Encrypted Data: #{encrypted}"
+  ```


### PR DESCRIPTION
## Description  
This PR adds a Ruby checker that detects the use of DSA (`OpenSSL::PKey::DSA`) for cryptographic operations. DSA is outdated, insecure, and should not be used for modern cryptographic needs.

## Detection Logic  
The checker flags instances where:  
- `OpenSSL::PKey::DSA` is used to generate or handle keys.

## Why is this a problem?  
- **Weak Key Sizes:** DSA commonly uses 1024-bit keys, which are vulnerable to brute-force attacks.  
- **Private Key Exposure:** Poor randomness in DSA signatures can leak private keys.  
- **Non-Compliance:** Modern standards like NIST discourage the use of DSA.  

## Recommended Remediation  
**Use Modern Cryptography:**  
- **Password Hashing:** Use `BCrypt` for securely hashing passwords.  
- **Encryption:** Use `AES-256-GCM` for secure encryption needs.  

## Example Fix  
```ruby
require 'bcrypt'

# Insecure: Using DSA (Avoid this)
require 'openssl'
dsa = OpenSSL::PKey::DSA.new(1024)  # Vulnerable and outdated

# Secure Alternative: BCrypt for Password Hashing
password = "SecurePassword123"
hashed_password = BCrypt::Password.create(password)
puts "BCrypt Hash: #{hashed_password}"

# Secure Alternative: AES-256-GCM for Encryption
require 'openssl'
cipher = OpenSSL::Cipher.new('aes-256-gcm')
cipher.encrypt
key = cipher.random_key
iv = cipher.random_iv
encrypted = cipher.update("Sensitive Data") + cipher.final
puts "AES Encrypted Data: #{encrypted}"
```

## Exclusions
The checker excludes test-related files to reduce false positives:
`test/**,*_test.rb,tests/**,__tests__/**`

##References
[OWASP Cryptographic Storage CheatSheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cryptographic_Storage_Cheat_Sheet.md)
