### PR TITLE
checker: ruby_rails_force_ssl

### DIFF
--- a/checkers/ruby/rails_force_ssl.test.rb
+++ b/checkers/ruby/rails_force_ssl.test.rb
@@ -1,0 +1,29 @@
+# config/application.rb
+
+require_relative 'boot'
+require 'rails/all'
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+
+Bundler.require(*Rails.groups)
+
+module SslExampleApp
+  class Application < Rails::Application
+    config.load_defaults 7.0
+
+    # Example methods to demonstrate force_ssl settings
+
+    def bad_ssl
+      # <expect-error> force-ssl false - This is unsafe and should not be used in production.
+      config.force_ssl = false
+      Rails.logger.warn("SSL is disabled. This is insecure and should be avoided in production environments.")
+    end
+
+    def ok_ssl
+      # safe force-ssl true - Enforces SSL, redirecting all HTTP requests to HTTPS.
+      config.force_ssl = true
+      Rails.logger.info("SSL is enabled. All HTTP requests will be redirected to HTTPS.")
+    end
+  end
+end

--- a/checkers/ruby/rails_force_ssl.yml
+++ b/checkers/ruby/rails_force_ssl.yml
@@ -1,0 +1,30 @@
+language: ruby
+name: ruby_force_ssl
+message: "Disablement of SSL detected. Enforce SSL to secure data in transit."
+category: security
+severity: warning
+pattern: >
+  (
+    (assignment
+      left: (call
+        method: (identifier) @method (#eq? @method "force_ssl"))
+      right: (false))
+  ) @ruby_force_ssl
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Disabling SSL (`config.force_ssl = false`) allows data to be transmitted over plaintext HTTP, making it vulnerable to interception, manipulation, and man-in-the-middle (MITM) attacks.  
+  Enforcing SSL ensures all HTTP traffic is redirected to HTTPS, securing data in transit.  
+
+  Remediation: 
+  Set `config.force_ssl = true` in your production environment configuration to enforce HTTPS:  
+
+  ```ruby
+  # config/environments/production.rb
+  Rails.application.configure do
+    config.force_ssl = true
+  end
+  ```


### PR DESCRIPTION
## Description  
This PR introduces a new Ruby checker that detects when SSL enforcement is disabled using `config.force_ssl = false`. Disabling SSL exposes applications to plaintext HTTP traffic, increasing the risk of data interception and man-in-the-middle (MITM) attacks.

## Detection Logic  
The checker flags instances where:  
- `force_ssl` is explicitly set to `false`.  

## Why is this a problem?  
- **Security Vulnerability:** Unencrypted HTTP traffic can be intercepted and manipulated.  
- **Compliance Issues:** Most security standards (e.g., PCI-DSS, GDPR) require encrypted data transmission.  
- **User Trust:** Browsers mark HTTP sites as insecure, harming user confidence.  

## Recommended Remediation  
Enable SSL by setting `config.force_ssl = true` in your production environment to enforce HTTPS.  

### Example Fix  
```ruby
# Insecure: SSL disabled (avoid this)
Rails.application.configure do
  config.force_ssl = false
end

# Secure: SSL enabled to protect data in transit
Rails.application.configure do
  config.force_ssl = true
end
```

## Exclusion

To avoid unnecessary noise, the checker excludes the following directories:
`[test/**,*_test.rb,tests/**,__tests__/**]
`
## References
[OWASP Transport Security Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html)
