### PR TITLE
checker: ruby_rails_http_hardcoded_passwd

### DIFF
--- a/checkers/ruby/rails_http_hardcoded_passwd.test.rb
+++ b/checkers/ruby/rails_http_hardcoded_passwd.test.rb
@@ -1,0 +1,12 @@
+class AdminController < ApplicationController
+  # Insecure: Hardcoded credentials (AVOID THIS)
+  # <expect-error> http basic auth hardcoded password
+  http_basic_authenticate_with name: "admin", password: "password"
+
+  # Secure: Using environment variables (Recommended)
+  http_basic_authenticate_with name: "admin", password: ENV['ADMIN_PASSWORD']
+
+  def index
+    render plain: "Welcome, Admin!"
+  end
+end

--- a/checkers/ruby/rails_http_hardcoded_passwd.yml
+++ b/checkers/ruby/rails_http_hardcoded_passwd.yml
@@ -1,0 +1,58 @@
+language: ruby
+name: ruby_rails_http_hardcoded_passwd
+message: "Avoid hardcoding passwords in HTTP authentication as it exposes sensitive credentials."
+category: security
+severity: critical
+pattern: >
+  (
+    (
+      call
+      method: (identifier) @auth_method
+      arguments: (argument_list
+        (pair
+          key: (hash_key_symbol) @credential_key
+          value: (string) @credential_string
+        )
+      )
+      (#eq? @auth_method "http_basic_authenticate_with")
+      (#match? @credential_key "password")
+      (#match? @credential_string "^\".*\"$")
+    )
+  ) @ruby_rails_http_hardcoded_passwd
+
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  Hardcoding passwords in HTTP authentication exposes sensitive credentials in the source code.
+  This increases the risk of credential leaks through version control, logs, and unauthorized access.
+
+  Why is this a problem?
+  - Security Risk: Hardcoded passwords can be extracted by attackers.
+  - Version Control Exposure: If committed, credentials can be accessed from Git history.
+  - Difficult to Rotate: Changing passwords requires modifying the source code.
+
+  Remediation:
+  - Use environment variables instead of hardcoded strings.
+  - Use Rails credentials to securely store secrets.
+
+  Example Fix:
+  ```ruby
+  class AdminController < ApplicationController
+    # Insecure: Hardcoded password (Avoid this)
+    http_basic_authenticate_with name: "admin", password: "password"
+
+    # Secure Alternative: Using environment variable
+    http_basic_authenticate_with name: "admin", password: ENV['ADMIN_PASSWORD']
+
+    # More Secure: Using Rails credentials
+    http_basic_authenticate_with name: "admin", password: Rails.application.credentials[:admin_password]
+
+    def index
+      render plain: "Welcome, Admin!"
+    end
+  end
+  ```


### PR DESCRIPTION
## Description  
This PR adds a new Ruby checker to identify instances of hardcoded passwords in HTTP authentication using `http_basic_authenticate_with`. Hardcoding passwords in source code exposes sensitive credentials, increasing the risk of leaks and unauthorized access.

## Detection Logic  
The checker flags cases where:  
- `http_basic_authenticate_with` is used with a direct string assignment to the `password` parameter.  

## Why is this a problem?  
- **Security Risk:** Attackers can extract hardcoded passwords from the codebase.  
- **Version Control Exposure:** Credentials may be exposed in Git history.  
- **Credential Management Issues:** Hardcoded passwords complicate rotation and increase maintenance burden.  

## Recommended Alternatives  
Replace hardcoded passwords with secure credential management solutions:  
- Use environment variables: `ENV['ADMIN_PASSWORD']`.  
- Use Rails credentials: `Rails.application.credentials[:admin_password]`.  

### Example Fix  
```ruby
class AdminController < ApplicationController
  # Insecure: Hardcoded password (avoid this)
  http_basic_authenticate_with name: "admin", password: "password"

  # Secure: Using environment variable
  http_basic_authenticate_with name: "admin", password: ENV['ADMIN_PASSWORD']

  # 🔒 More Secure: Using Rails credentials
  http_basic_authenticate_with name: "admin", password: Rails.application.credentials[:admin_password]

  def index
    render plain: "Welcome, Admin!"
  end
end
```

## Exclusion
The checker ignores files in the following directories to reduce noise:
[test/**,*_test.rb,tests/**,__tests__/**]

# References
[OWASP Secret Management CheatSheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)