### PR TITLE
checker: ruby_rails_samesite_cookie

### DIFF
--- a/checkers/ruby/rails_samesite_cookie.test.rb
+++ b/checkers/ruby/rails_samesite_cookie.test.rb
@@ -1,0 +1,12 @@
+# config/initializers/session_store.rb
+
+# Insecure: SameSite set to 'None' (can lead to CSRF attacks if Secure flag is not enabled)
+# <expect-error> samesite none
+Rails.application.config.session_store :cookie_store, key: "_myapp_session", same_site: :none
+
+# Insecure: Missing 'same_site' attribute (defaults to Lax but can be risky in certain cases)
+# <expect-error> empty samesite
+Rails.application.config.session_store :cookie_store, key: "_myapp_session", httponly: true
+
+# Secure: SameSite set to 'Strict' (Prevents CSRF attacks by restricting cookies to first-party requests)
+Rails.application.config.session_store :cookie_store, key: "_myapp_session", same_site: :strict, httponly: true, secure: Rails.env.production?

--- a/checkers/ruby/rails_samesite_cookie.yml
+++ b/checkers/ruby/rails_samesite_cookie.yml
@@ -1,0 +1,62 @@
+language: ruby
+name: ruby_rails_samesite_cookie
+message: "Avoid using SameSite=None attribute in cookies to prevent CSRF attacks."
+category: security
+severity: critical
+patterns: 
+  - >
+    (
+      call
+      receiver: (call
+        receiver: (call
+          receiver: (constant) @rails
+          method: (identifier) @application
+        )
+        method: (identifier) @config
+      )
+      method: (identifier) @store_method
+      arguments: (argument_list
+        (simple_symbol) @store_type
+        (
+        pair
+          key: (hash_key_symbol) @setting_key
+          value: (simple_symbol) @setting_value
+        (#eq? @setting_key "same_site")
+        (#eq? @setting_value ":none")
+      ))
+    ) @ruby_rails_samesite_cookie
+  - >
+    (
+      call
+      receiver: (call
+        receiver: (call
+          receiver: (constant) @rails
+          method: (identifier) @application
+        )
+        method: (identifier) @config
+      )
+      method: (identifier) @store_method
+      arguments: (argument_list
+        (simple_symbol) @store_type
+        ) @args
+        (#not-match? @args "same_site")
+    ) @ruby_rails_samesite_cookie
+
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Using SameSite=None in session cookies allows them to be sent with cross-site requests. This can increase the risk of Cross-Site Request Forgery (CSRF) attacks, 
+  where an attacker tricks a user into making unwanted actions on a trusted site.
+  Risks of SameSite=None:
+    - Allows cookies to be sent in cross-origin requests, making them vulnerable to CSRF.
+    - Attackers can exploit this to impersonate users on another domain.
+    - This setting should only be used when Secure is explicitly enabled (for HTTPS).
+  Remediation:
+    Use SameSite=Strict or SameSite=Lax to prevent CSRF.
+  Example Fix:
+    ```ruby
+    Rails.application.config.session_store :cookie_store, key: "_myapp_session", same_site: :strict, httponly: true, secure: Rails.env.production?
+    ```


### PR DESCRIPTION
## Description  
This PR adds a new Ruby checker to detect insecure cookie configurations using `SameSite=None` or missing the `same_site` attribute in Rails applications. Using `SameSite=None` allows cookies to be sent with cross-site requests, increasing the risk of Cross-Site Request Forgery (CSRF) attacks. Without proper configuration, attackers can exploit this to impersonate users or perform unauthorized actions.

## Detection Logic  
The checker flags the following cases:  
- Usage of `same_site: :none` in session or cookie store configurations.  
- Missing `same_site` attribute in session or cookie store configurations.

## Why is this a problem?  
- **CSRF Vulnerability:** Cookies sent with cross-origin requests can be used in CSRF attacks.  
- **User Impersonation:** Attackers can exploit this to perform actions on behalf of authenticated users.  
- **Security Standards:** Using `SameSite=None` without the `secure` flag violates best security practices.

## Recommended Alternatives  
Use `SameSite=Strict` or `SameSite=Lax` to mitigate CSRF risks:  

### Example Fix  
```ruby
# Insecure (vulnerable to CSRF)
Rails.application.config.session_store :cookie_store, key: "_myapp_session", same_site: :none

# Secure (recommended)
Rails.application.config.session_store :cookie_store, key: "_myapp_session", same_site: :strict, httponly: true, secure: Rails.env.production?
```

## Exclusions
To reduce noise, the checker does not flag occurrences in:
Test files (*_test.rb, test/**, tests/**, __tests__/**)

## References
[MDN Web Docs: SameSite Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)