### PR TITLE
checker: ruby_rails_unsafe_direct_assignment

### DIFF
--- a/checkers/ruby/rails_unsafe_direct_assignment.test.rb
+++ b/checkers/ruby/rails_unsafe_direct_assignment.test.rb
@@ -1,0 +1,44 @@
+class User < ApplicationRecord
+  # Insecure: Allows mass assignment of all attributes, which can lead to privilege escalation or unauthorized data modification.
+  # <expect-error> unsafe direct assignment
+  attr_accessible :all
+end
+
+
+#Safe
+class User < ApplicationRecord
+  # Removed attr_accessible (deprecated and unsafe)
+end
+
+
+class UsersController < ApplicationController
+  before_action :set_user, only: [:show, :update, :destroy]
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      render json: @user, status: :created
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      render json: @user
+    else
+      render json: @user.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  # Strong parameters: Only permits safe attributes.
+  def user_params
+    params.require(:user).permit(:name, :email, :password)
+  end
+end

--- a/checkers/ruby/rails_unsafe_direct_assignment.yml
+++ b/checkers/ruby/rails_unsafe_direct_assignment.yml
@@ -1,0 +1,34 @@
+language: ruby
+name: ruby_rails_unsafe_direct_assignment
+message: "Avoid using 'attr_accessible :all' to prevent mass assignment vulnerabilities."
+category: security
+severity: critical
+pattern: >
+  (
+    call
+      method: (identifier) @method
+      arguments: (argument_list
+        (simple_symbol) @symbol
+      )
+    (#eq? @method "attr_accessible")
+    (#match? @symbol "^:all$")
+  ) @ruby_rails_unsafe_direct_assignment
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Using `attr_accessible :all` allows mass assignment of all model attributes, which can lead to security vulnerabilities like privilege escalation and unauthorized data modification.  
+  Attackers may exploit this to modify sensitive fields (e.g., `admin`, `role`, `balance`) through crafted requests.
+
+  Remediation: 
+  Remove `attr_accessible :all` and use strong parameters to explicitly whitelist permitted attributes:
+
+  ```ruby
+  # Insecure (vulnerable to mass assignment)
+  attr_accessible :all
+
+  # Secure (with strong parameters)
+  params.require(:user).permit(:name, :email, :password)
+  ```


### PR DESCRIPTION
## Description  
This PR adds a new Ruby checker to detect the use of `attr_accessible :all`, which enables mass assignment of all model attributes. This practice can lead to serious security vulnerabilities, including privilege escalation and unauthorized data modifications. Attackers can exploit this to alter sensitive fields such as `admin`, `role`, or `balance` through crafted requests.

## Detection Logic  
The checker flags the following case:  
- Usage of `attr_accessible :all` in Rails models.

## Why is this a problem?  
- **Privilege Escalation:** Attackers can gain elevated permissions by modifying sensitive fields.  
- **Unauthorized Data Access:** Mass assignment can lead to unintended attribute changes.  
- **Data Integrity Risks:** Allows untrusted input to manipulate protected model attributes.

## Recommended Alternatives  
Instead of using `attr_accessible :all`, use **strong parameters** to explicitly permit only the required attributes:  

### Example Fix  
```ruby
# insecure (vulnerable to mass assignment)
attr_accessible :all

# Secure (using strong parameters)
params.require(:user).permit(:name, :email, :password)
```

## Exclusions
To reduce noise, the checker does not flag occurrences in:

Test files (*_test.rb, test/**, tests/**, __tests__/**)
References
Rails Strong Parameters Guide
OWASP Top 10: Injection Vulnerabilities

## Reference
[Securing ruby rails](https://www.mintbit.com/blog/securing-ruby-on-rails-applications-part-3-use-strong-parameters/)