### PR TITLE
checker: ruby_rsa_weak_crypto

### DIFF
--- a/checkers/ruby/rsa_weak_crypto.test.rb
+++ b/checkers/ruby/rsa_weak_crypto.test.rb
@@ -1,0 +1,14 @@
+require 'openssl'
+require 'base64'
+require 'bcrypt'
+
+def generate_dsa_key
+  # <expect-error> Use of RSA key (not recommended)
+  dsa = OpenSSL::PKey::RSA.new(1024)
+  dsa
+end
+
+# Safe - Hashing a password securely using bcrypt
+def hash_password(password)
+  BCrypt::Password.create(password) # Automatically generates a salt
+end

--- a/checkers/ruby/rsa_weak_crypto.yml
+++ b/checkers/ruby/rsa_weak_crypto.yml
@@ -1,0 +1,51 @@
+language: ruby
+name: ruby_rsa_weak_crypto
+message: "Avoid using RSA for cryptographic operations; it is outdated and insecure."
+category: security
+severity: critical
+pattern: >
+  (scope_resolution
+  scope: (scope_resolution
+    scope: (constant) @openssl (#eq? @openssl "OpenSSL")
+    name: (constant) @pkey (#eq? @pkey "PKey"))
+  name: (constant) @rsa (#eq? @rsa "RSA")) @ruby_rsa_weak_crypto
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Issue:
+  RSA is considered weak due to its reliance on small key sizes and vulnerability 
+  to attacks.It is no longer recommended for cryptographic operations.
+
+  Why is this a problem?
+  - RSA with small key sizes (1024-bit) is vulnerable to brute-force attacks.
+  - Poor randomness in RSA signatures can lead to private key leaks.
+  - Modern security standards recommend stronger alternatives.
+
+  Remediation:
+  - Instead of RSA, use BCrypt for securely hashing passwords.
+  - If encryption is needed, use AES-256-GCM.
+
+  Example Fix:
+  ruby
+  require 'bcrypt'
+
+  # Weak RSA (Avoid)
+  require 'openssl'
+  rsa = OpenSSL::PKey::RSA.new(1024)  # Weak & insecure
+
+  # Secure BCrypt Alternative (for password hashing)
+  password = "SecurePassword123"
+  hashed_password = BCrypt::Password.create(password)
+  puts "BCrypt Hash: #{hashed_password}"
+
+  # Secure AES Alternative (for encryption)
+  require 'openssl'
+  cipher = OpenSSL::Cipher.new('aes-256-gcm')
+  cipher.encrypt
+  key = cipher.random_key
+  iv = cipher.random_iv
+  encrypted = cipher.update("Sensitive Data") + cipher.final
+  puts "AES Encrypted Data: #{encrypted}"


### PR DESCRIPTION
## Description  
This PR adds a new Ruby checker to detect the use of `OpenSSL::PKey::RSA` for cryptographic operations. RSA is considered outdated and insecure, especially with small key sizes (e.g., 1024-bit), making it vulnerable to brute-force and key leakage attacks. This checker is flagged as a critical security issue to encourage the use of modern and secure cryptographic alternatives.

## Detection Logic  
The checker flags the following case:  
- Usage of `OpenSSL::PKey::RSA` for encryption, decryption, or key generation.

## Why is this a problem?  
- **Weak Key Sizes:** RSA with 1024-bit keys is susceptible to brute-force attacks.  
- **Poor Randomness:** Flaws in RSA signatures can expose private keys.  
- **Outdated Standard:** Modern cryptographic standards discourage RSA usage in favor of more secure algorithms.

## Recommended Alternatives  
Instead of RSA, consider:  
- **For Password Hashing:** Use `BCrypt` for secure password storage.  
- **For Encryption:** Use `AES-256-GCM` for secure encryption and data integrity.

### Example Fix  
```ruby
require 'bcrypt'

# Weak RSA (Avoid)
require 'openssl'
rsa = OpenSSL::PKey::RSA.new(1024)  # Weak & insecure

# Secure BCrypt Alternative (for password hashing)
password = "SecurePassword123"
hashed_password = BCrypt::Password.create(password)
puts "BCrypt Hash: #{hashed_password}"

# Secure AES Alternative (for encryption)
require 'openssl'
cipher = OpenSSL::Cipher.new('aes-256-gcm')
cipher.encrypt
key = cipher.random_key
iv = cipher.random_iv
encrypted = cipher.update("Sensitive Data") + cipher.final
puts "AES Encrypted Data: #{encrypted}"
```

# Exclusions
To reduce noise, the checker does not flag occurrences in:
Test files (*_test.rb, test/**, tests/**, __tests__/**)

# References
NIST Guidelines for Cryptographic Standards (https://csrc.nist.gov/pubs/sp/800/131/a/r2/final)
