### PR TITLE
checker: ruby_sha1_weak_hash

### DIFF
--- a/checkers/ruby/sha1_weak_hash.test.rb
+++ b/checkers/ruby/sha1_weak_hash.test.rb
@@ -1,0 +1,25 @@
+require 'digest'
+
+class HashGenerator
+  # Insecure: Uses SHA-1, which is vulnerable to collision attacks.
+  def generate_sha1_hash(string)
+    # <expect-error> use of sha1
+    Digest::SHA1.hexdigest(string)
+  end
+
+  # Secure: Uses SHA-256, a stronger and recommended hash function.
+  def generate_sha256_hash(string)
+    # safe hash function
+    Digest::SHA256.hexdigest(string)
+  end
+end
+
+hash_generator = HashGenerator.new
+
+input = "sensitive_data"
+
+sha1_hash = hash_generator.generate_sha1_hash(input)
+puts "SHA-1 Hash (insecure): #{sha1_hash}"
+
+sha256_hash = hash_generator.generate_sha256_hash(input)
+puts "SHA-256 Hash (secure): #{sha256_hash}"

--- a/checkers/ruby/sha1_weak_hash.yml
+++ b/checkers/ruby/sha1_weak_hash.yml
@@ -1,0 +1,30 @@
+language: ruby
+name: ruby_sha1_weak_hash
+message: "Avoid using SHA-1 to hash sensitive data as it is cryptographically weak."
+category: security
+severity: critical
+pattern: >
+  [
+    (scope_resolution
+      scope: (constant) @digest (#eq? @digest "Digest")
+      name: (constant) @sha1 (#eq? @sha1 "SHA1"))
+    @ruby_sha1_weak_hash
+  ]
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  The SHA-1 hashing algorithm is considered cryptographically weak and is vulnerable to collision attacks.  
+  Using SHA-1 to hash sensitive data, such as passwords or digital signatures, exposes applications to significant security risks, including data forgery and integrity breaches.  
+
+  Remediation:  
+  Replace `Digest::SHA1` with a stronger hashing algorithm like `Digest::SHA256`:  
+
+  ruby
+  # Insecure (vulnerable to collisions)
+  Digest::SHA1.hexdigest("sensitive_data")
+
+  # Secure (recommended)
+  Digest::SHA256.hexdigest("sensitive_data")


### PR DESCRIPTION
**Description**  
This PR adds a new Ruby checker to detect the use of `Digest::SHA1`, which relies on the SHA-1 hashing algorithm. SHA-1 is considered cryptographically weak and is vulnerable to collision attacks, exposing applications to data forgery and integrity breaches. This checker is flagged as a critical security issue to ensure stronger hashing mechanisms are used.

**Detection Logic**  
The checker flags the following case:  
[x] Usage of `Digest::SHA1` for hashing sensitive data.

**Recommended Alternatives**  
Instead of using SHA-1, replace it with a stronger hashing algorithm such as `Digest::SHA256`:  

**Examples**  
ruby
**Insecure (vulnerable to collisions)**
Digest::SHA1.hexdigest("sensitive_data")

**Secure (recommended)**
Digest::SHA256.hexdigest("sensitive_data")

**Exclusions**
To reduce noise, the checker does not flag occurrences in:
Test files (*_test.rb, test/**, tests/**, __tests__/**)

**Reference**
[NIST Policy on Hash Functions](https://csrc.nist.gov/projects/hash-functions)