### PR TITLE
checker: ruby_skip_authorization

### DIFF
--- a/checkers/ruby/skip_authorization.test.rb
+++ b/checkers/ruby/skip_authorization.test.rb
@@ -1,0 +1,31 @@
+class PostsController < ApplicationController
+  # Insecure: Skips authorization checks for all actions, exposing the app to unauthorized access.
+  # <expect-error> Skipping authorization for all actions
+  skip_authorization_check
+
+  def index
+    @posts = Post.all
+    render json: @posts
+  end
+
+  def show
+    @post = Post.find(params[:id])
+    render json: @post
+  end
+end
+
+
+class PostsController < ApplicationController
+  # Safe Ensure authorization checks are performed for all actions.
+  before_action :authenticate_user!      # Ensures only logged-in users can access.
+  load_and_authorize_resource           # CanCanCan method to load resource and check permissions.
+
+  def index
+    # @posts is automatically loaded and authorized by load_and_authorize_resource.
+    render json: @posts
+  end
+
+  def show
+    render json: @post
+  end
+end

--- a/checkers/ruby/skip_authorization.yml
+++ b/checkers/ruby/skip_authorization.yml
@@ -1,0 +1,38 @@
+language: ruby
+name: ruby_skip_authorization
+message: "Avoid skipping authorization checks to prevent unauthorized access."
+category: security
+severity: critical
+pattern: >
+  (
+    (identifier) @skip_auth
+    (#match? @skip_auth "^skip_authorization_check.*")
+  ) @ruby_skip_authorization
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Skipping authorization checks using `skip_authorization_check` can expose your application to unauthorized access, allowing users to perform actions or view data they should not have access to.  
+  This practice bypasses critical security layers, increasing the risk of privilege escalation and data leakage.
+
+  Remediation:  
+    Remove `skip_authorization_check` and implement proper authorization mechanisms. Use libraries like [CanCanCan](https://github.com/CanCanCommunity/cancancan) or [Pundit](https://github.com/varvet/pundit) to enforce authorization policies:
+
+  ruby
+    class PostsController < ApplicationController
+  # Safe Ensure authorization checks are performed for all actions.
+  before_action :authenticate_user!      # Ensures only logged-in users can access.
+  load_and_authorize_resource           # CanCanCan method to load resource and check permissions.
+
+  def index
+    # @posts is automatically loaded and authorized by load_and_authorize_resource.
+    render json: @posts
+  end
+
+  def show
+    render json: @post
+  end
+  end
+


### PR DESCRIPTION
**Description**  
This PR adds a new Ruby checker to detect the use of `skip_authorization_check`, which skips essential authorization checks. Skipping these checks can expose applications to unauthorized access, allowing users to perform actions or access data beyond their permissions. This checker is flagged as a critical security issue to prevent privilege escalation and data leakage.

**Detection Logic**  
The checker flags the following case:  
- Usage of methods matching `skip_authorization_check*`

**Recommended Alternatives**  
Instead of skipping authorization checks, consider:  
- Removing `skip_authorization_check` calls.  
- Implementing proper authorization mechanisms using libraries like:  
  - [CanCanCan](https://github.com/CanCanCommunity/cancancan)  
  - [Pundit](https://github.com/varvet/pundit)  

**Example (Safe Alternative using CanCanCan):**  
```ruby
class PostsController < ApplicationController
  before_action :authenticate_user!      # Ensures only logged-in users can access.
  load_and_authorize_resource            # Loads resource and checks permissions.

  def index
    render json: @posts  # @posts is automatically authorized.
  end

  def show
    render json: @post
  end
end

**Exclusions**
To reduce noise, the checker does not flag occurrences in:
Test files (*_test.rb, test/**, tests/**, __tests__/**)
