### PR TITLE
checker: ruby_ssl_no_verify

### DIFF
--- a/checkers/ruby/ssl_no_verify.test.rb
+++ b/checkers/ruby/ssl_no_verify.test.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+require 'openssl'
+
+# Insecure: Disabling SSL certificate verification (Vulnerable to MITM attacks)
+def insecure_ssl_request(url)
+  uri = URI.parse(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+  
+  # <expect-error> ssl no verify (Disables SSL verification)
+  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  request = Net::HTTP::Get.new(uri.request_uri)
+  response = http.request(request)
+  response.body
+end
+
+# Secure: Enabling SSL certificate verification (Prevents MITM attacks)
+def secure_ssl_request(url)
+  uri = URI.parse(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+
+  # Secure verification of SSL certificates
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+  request = Net::HTTP::Get.new(uri.request_uri)
+  response = http.request(request)
+  response.body
+end

--- a/checkers/ruby/ssl_no_verify.yml
+++ b/checkers/ruby/ssl_no_verify.yml
@@ -1,0 +1,31 @@
+language: ruby
+name: ruby_ssl_no_verify
+message: "Avoid disabling SSL verification as it makes the application vulnerable to MITM attacks."
+category: security
+severity: critical
+pattern: >
+  (scope_resolution
+    scope: (scope_resolution
+      scope: (constant) @openssl (#eq? @openssl "OpenSSL")
+      name: (constant) @ssl (#eq? @ssl "SSL"))
+    name: (constant) @verify (#eq? @verify "VERIFY_NONE")) @ruby_ssl_no_verify
+exclude:
+  - "test/**"
+  - "*_test.rb"
+  - "tests/**"
+  - "__tests__/**"
+description: |
+  Disabling SSL verification (`OpenSSL::SSL::VERIFY_NONE`) exposes the application to Man-in-the-Middle (MITM) attacks, allowing attackers to intercept and manipulate sensitive data in transit.  
+  SSL/TLS certificate verification ensures the authenticity and integrity of the server you are communicating with, protecting against eavesdropping and data tampering.
+
+  Remediation:  
+  Always enable SSL verification by using `OpenSSL::SSL::VERIFY_PEER`:
+
+  ruby
+  # Insecure (disables SSL verification)
+  ssl_context = OpenSSL::SSL::SSLContext.new
+  ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+  # Secure (verifies SSL certificates)
+  ssl_context = OpenSSL::SSL::SSLContext.new
+  ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER


### PR DESCRIPTION
**Description**  
This PR adds a new Ruby checker to detect the use of `OpenSSL::SSL::VERIFY_NONE`, which disables SSL/TLS certificate verification. Disabling verification exposes applications to Man-in-the-Middle (MITM) attacks, allowing attackers to intercept and manipulate sensitive data in transit. This checker is flagged as a security issue to ensure SSL certificates are always validated.

**Detection Logic**  
The checker flags the following case:  
- Setting `ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE`

**Recommended Alternatives**  
Instead of disabling SSL verification, consider:  
- Using `OpenSSL::SSL::VERIFY_PEER` to verify certificates and ensure secure communications.  
- Properly configuring trusted certificate authorities (CAs) for SSL connections.

**Exclusions**  
To reduce noise, the checker does not flag occurrences in:  
- Test files  
- Vendor dependencies  
- Development-only environments  

**References**  
- [CWE-295: Improper Certificate Validation](https://cwe.mitre.org/data/definitions/295.html)  
- [OWASP Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)  
