### PR TITLE
php: dangerous eval

### DIFF
--- a/checkers/php/dangerous_eval.test.php
+++ b/checkers/php/dangerous_eval.test.php
@@ -1,0 +1,33 @@
+<?php
+
+function test_dangerous_eval() {
+    $user_input = $_GET['input'];
+
+    // These should be flagged
+    // <expect-error>
+    eval($user_input);
+
+    // <expect-error>
+    eval("echo " . $user_input . "hi");
+
+    // String interpolation
+    // <expect-error>
+    eval("echo $user_input");
+
+    // Superglobal (outside our control) sources
+    // <expect-error>
+    eval($_GET['username']);
+
+    // These are safe and should not be flagged
+    // constants
+    eval('echo "Hello, World!"');
+
+}
+
+function test_edge_cases() {
+    // Should not flag eval in variable names
+    $evaluation_result = 100;
+
+    // Should not flag commented-out eval
+    // eval($user_input);
+}

--- a/checkers/php/dangerous_eval.yml
+++ b/checkers/php/dangerous_eval.yml
@@ -1,0 +1,78 @@
+language: php
+name: dangerous_eval
+message: "Avoid using eval() with dynamic inputs as it can lead to remote code execution (RCE) vulnerabilities"
+category: security
+severity: critical
+
+pattern: |
+  ;; Match direct eval calls with variable input
+  (expression_statement
+    (function_call_expression
+      function: (name) @function (#eq? @function "eval")
+      arguments: (arguments
+        (argument
+          (variable_name) @user_input
+        )
+      )
+    )
+  ) @dangerous_eval
+
+  ;; Match eval calls with string concatenation
+  (expression_statement
+    (function_call_expression
+      function: (name) @function (#eq? @function "eval")
+      arguments: (arguments
+        (argument
+          (binary_expression
+            left: [
+              (encapsed_string)
+              (binary_expression)
+            ]
+            right: [
+              (encapsed_string)
+              (variable_name) @user_input
+            ]
+          )
+        )
+      )
+    )
+  ) @dangerous_eval
+
+  ;; Match eval calls with interpolated strings containing variables
+  (expression_statement
+    (function_call_expression
+      function: (name) @function (#eq? @function "eval")
+      arguments: (arguments
+        (argument
+          (encapsed_string
+            (variable_name) @user_input
+          )
+        )
+      )
+    )
+  ) @dangerous_eval
+
+  ;; Match eval calls with superglobal input sources
+  (expression_statement
+    (function_call_expression
+      function: (name) @function (#eq? @function "eval")
+      arguments: (arguments
+        (argument
+          (subscript_expression
+            (variable_name (name) @superglobal)
+            (#match? @superglobal "^_(GET|POST|REQUEST|COOKIE|SERVER|ENV|FILES|SESSION)$")
+          )
+        )
+      )
+    )
+  ) @dangerous_eval
+
+exclude:
+  - "tests/**"
+  - "vendor/**"
+  - "**/test_*.php"
+  - "**/*_test.php"
+
+description: |
+  The use of eval() in PHP without validating the input can lead to the execution
+  of arbitrary code, resulting in potential remote code execution (RCE) vulnerabilities.


### PR DESCRIPTION
## Description
This PR introduces a new security checker named `dangerous_eval` to detect unsafe usage of `eval()` in PHP code. The use of `eval()` can lead to severe security vulnerabilities, including remote code execution (RCE), especially when combined with user-controlled input.

## Detection Logic
The checker flags the following unsafe patterns:
- [x] **Direct usage of `eval()` with a variable input**  
- [x] **`eval()` with string concatenation involving user input**  
- [x] **`eval()` with interpolated strings containing variables**  
- [x] **`eval()` with PHP superglobal  variables (variables that are populated externally) (`$_GET`, `$_POST`, `$_REQUEST`, etc.)**  
