### PR TITLE
java: unsafe file traversal

### DIFF
--- a/checkers/java/unsafe_path_traversal.test.java
+++ b/checkers/java/unsafe_path_traversal.test.java
@@ -1,0 +1,27 @@
+public class UnsafePathTraversalTest {
+
+  // These should be flagged
+  public void testVulnerable() {
+    String userInput = request.getParameter("file");
+
+    // <expect-error>
+    File file1 = new File(userInput);
+
+    // <expect-error>
+    File file2 = new File("/var/data/" + userInput + "test");
+
+    // <expect-error>
+    File file3 = new File(String.format("/var/www/uploads/%s", userInput));
+  }
+
+  // These should not be flagged
+  public void testSafe() {
+    String userInput = request.getParameter("file");
+
+    // path is commented
+    // File file3 = new File(userInput);
+
+    // Safe usage: constant file path used
+    File file4 = new File("/var/data/file.txt");
+  }
+}

--- a/checkers/java/unsafe_path_traversal.yml
+++ b/checkers/java/unsafe_path_traversal.yml
@@ -1,0 +1,54 @@
+language: java
+name: unsafe_path_traversal
+message: "Avoid using File() with dynamic input as it can lead to path traversal vulnerabilities"
+category: security
+severity: critical
+
+pattern: |
+  (object_creation_expression
+    type: (type_identifier) @type
+    arguments: (argument_list
+      [
+        ; Direct user input in File constructor
+        (identifier) @user_input
+        
+        ; String concatenation with user input
+        (binary_expression
+          left: [
+            (identifier) @user_input
+            (string_literal)
+            (binary_expression)
+          ]
+          right: [
+            (identifier) @user_input
+            (string_literal)
+          ]
+        )
+
+        ; String.format with user input
+        (method_invocation
+          object: (identifier) @format_obj
+          name: (identifier) @format_method
+          arguments: (argument_list
+            (string_literal)
+            (identifier) @user_input)
+        )
+      ]
+    ) @unsafe_path_traversal
+
+    (#eq? @type "File")
+    (#any-of? @format_obj "String")
+    (#any-of? @format_method "format")
+  )
+          
+exclude:
+  - "tests/**"
+  - "vendor/**"
+  - "**/Test_*.java"
+  - "**/*Test.java"
+
+description: |
+  Using File() with unvalidated input can lead to path traversal
+  vulnerabilities (CWE-22), allowing unauthorized file access. To prevent
+  exploitation, avoid dynamic path construction, and use secure APIs like
+  Paths.get() with strict access controls.


### PR DESCRIPTION
## Description
This PR introduces a new java security checker named `unsafe_file_traversal` to detect potential path traversal vulnerabilities in Java. Improper handling of file paths, especially when constructed dynamically with user input, can allow attackers to access unauthorized files, leading to security risks such as information disclosure, arbitrary file access, or file manipulation.

## Detection Logic
The checker flags the following unsafe patterns:
- [x] **Direct usage of `File()` with user-controlled input**
- [x] **`File()` with string concatenation involving user input**
- [x] **`File()` with `String.format()` where user input is used in formatting**

## Exclusions
This checker excludes test directories and vendor dependencies to reduce false positives.
