### PR TITLE
rust: avoid using unwrap()

### DIFF
--- a/checkers/rust/avoid_unwrap.test.rs
+++ b/checkers/rust/avoid_unwrap.test.rs
@@ -1,0 +1,25 @@
+fn test_antipattern() {
+    // These should be flagged
+    let some_option: Option<i32> = None;
+
+    // <expect-error>
+    let _ = some_option.unwrap();
+
+    let some_result: Result<i32, &str> = Err("Error occurred");
+
+    // <expect-error>
+    let _ = some_result.unwrap();
+
+}
+
+fn test_safe() {}
+    // These are safe and should not be flagged
+
+    // Handling Option safely
+    let _ = some_option.unwrap_or(42); // Providing a default value
+
+    // some_option.unwrap();
+
+    // Should not flag string literals containing "unwrap"
+    let message = "Do not use unwrap in production!";
+}

--- a/checkers/rust/avoid_unwrap.yml
+++ b/checkers/rust/avoid_unwrap.yml
@@ -1,0 +1,28 @@
+language: rust
+name: avoid_unwrap
+message: "Using unwrap() may cause panics if the Option is None or the Result is Err, consider handling errors with match or expect()"
+category: antipattern
+severity: warning
+
+pattern: |
+  (
+    (call_expression
+      function: (field_expression
+        value: (_) @variable
+        field: (field_identifier) @method_name
+        (#eq? @method_name "unwrap")
+      )
+      arguments: (arguments)
+    ) @avoid_unwrap
+  )
+
+exclude:
+  - "tests/**"
+  - "vendor/**"
+  - "**/test_*.rs"
+  - "**/*_test.rs"
+
+description: |
+  The use of .unwrap() in Rust can lead to unexpected panics if the value is None (for Option) or Err (for Result).
+  This can lead to crashes in production and make debugging harder. Consider handling errors explicitly with match
+  or use expect() if a panic is acceptable.


### PR DESCRIPTION
## Description
This PR adds a new rust checker to detect the use of `.unwrap()` in Rust code. While `.unwrap()` is convenient, it can lead to unexpected panics and is only meant for quick prototyping (see [rust error handling](https://doc.rust-lang.org/book/ch09-03-to-panic-or-not-to-panic.html#examples-prototype-code-and-tests)). This checker is flagged as an `antipattern` since it does not impact security much.

## Detection Logic
The checker flags the following cases:
- [x] **Calling `.unwrap()` on an `Option` or `Result`**  

## Recommended Alternatives
Instead of using `.unwrap()`, consider:
- Handling errors explicitly using `match` or `if let`
- Using `.unwrap_or_else()` to provide a fallback value or handle errors gracefully
- Using `.expect()` with a meaningful message if a panic is intentional  

## Exclusions
To reduce noise, the checker does not flag occurrences in test files, vendor dependencies, or test directories.
