### PR TITLE
[Feat] Python: checker for usage of assert statements

### DIFF
--- a/checkers/python/avoid_assert.test.py
+++ b/checkers/python/avoid_assert.test.py
@@ -1,0 +1,9 @@
+def divide(a, b):
+    # <expect-error>
+    assert b != 0
+    return a / b
+
+# <expect-error>
+assert 1 == 1
+# <expect-error>
+assert 1 == 2

--- a/checkers/python/avoid_assert.yml
+++ b/checkers/python/avoid_assert.yml
@@ -1,0 +1,21 @@
+language: python
+name: avoid-assert
+message: "Avoid assert to enforce constraints. Assert statements are removed in optimised bytecode."
+category: bug-risk
+severity: info
+
+pattern: >
+    (
+      assert_statement
+    ) @avoid-assert
+
+exclude:
+  - "test/**"
+  - "*_test.py"
+  - "tests/**"
+  - '*test_*.py'
+    
+description: |
+  Using assert statements for enforcing constraints is risky because they are removed when Python is run in optimized mode (`python -O`).  
+  This can lead to unintended behavior, especially for security checks and critical logic.  
+  Instead, use explicit condition checks with exceptions (e.g., `if not condition: raise ValueError(...)`).


### PR DESCRIPTION
## Description
Using assert statements for enforcing constraints is risky because they are removed when Python optimizes for production code (`python -O`).  This can lead to unintended behaviour, especially for security checks and critical logic. Instead, use explicit condition checks with exceptions (e.g., `if not condition: raise ValueError(...)`).

## Type of change
- [x] New checker

## Checklist
- [x] All new checkers are in the `checkers` directory
- [x] I have added tests
- [x] Checker YAML files follow the required format
- [x] CI checks are passing

## Additional Notes
Refer to [Python docs for assert](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement) about the behaviour in optimised code.