### PR TITLE
Python: Go Interface based Checker for SQL injection vulnerability

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -9,6 +9,7 @@ import (
 
 	goAnalysis "globstar.dev/analysis"
 	"globstar.dev/checkers/javascript"
+	"globstar.dev/checkers/python"
 	"globstar.dev/pkg/analysis"
 )
 
@@ -68,6 +69,10 @@ var AnalyzerRegistry = []Analyzer{
 	{
 		TestDir:   "checkers/javascript/testdata", // relative to the repository root
 		Analyzers: []*goAnalysis.Analyzer{javascript.NoDoubleEq, javascript.SQLInjection},
+	},
+	{
+		TestDir:   "checkers/python/testdata", // relative to the repository root
+		Analyzers: []*goAnalysis.Analyzer{python.AvoidUnsanitizedSQL},
 	},
 }
 

--- a/checkers/python/avoid-unsanitized-sql.go
+++ b/checkers/python/avoid-unsanitized-sql.go
@@ -42,8 +42,10 @@ func checkSQLInjection(r analysis.Rule, ana *analysis.Analyzer, node *sitter.Nod
 	// If the query string is built unsafely, report an issue.
 	if isUnsafeString(firstArg, source) {
 		ana.Report(&analysis.Issue{
-			Message: "Direct use of unsafe string in SQL query",
-			Range:   node.Range(),
+			Message:  "Concatenated string in SQL query is an SQL injection threat!",
+			Category: analysis.CategorySecurity,
+			Severity: analysis.SeverityCritical,
+			Range:    node.Range(),
 		})
 		return
 	}

--- a/checkers/python/avoid-unsanitized-sql.go
+++ b/checkers/python/avoid-unsanitized-sql.go
@@ -1,0 +1,293 @@
+package python
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+// SQLInjection creates an analyzer that detects unsafe SQL query construction.
+func SQLInjection() *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:        "sql-injection",
+		Description: "Detects unsafe SQL query construction",
+		Category:    analysis.CategorySecurity,
+		Severity:    analysis.SeverityCritical,
+		Language:    analysis.LangPy, // assuming LangPy is defined elsewhere
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			// Define an inner function that captures pass.
+			fn := func(n *sitter.Node) {
+				visitCall(pass, n)
+			}
+			analysis.Preorder(pass, fn)
+			return nil, nil
+		},
+	}
+}
+
+// visitCall checks if a call node is a SQL execution call and if its arguments are unsafe.
+func visitCall(pass *analysis.Pass, node *sitter.Node) {
+	source := pass.FileContext.Source
+
+	// Only process call nodes.
+	if node.Type() != "call" {
+		return
+	}
+
+	// Extract the function part (e.g. cursor.execute).
+	functionNode := node.ChildByFieldName("function")
+	if functionNode == nil {
+		return
+	}
+
+	// Proceed only if the function is one of our recognized SQL methods.
+	if !isSQLExecuteMethod(functionNode, source) {
+		return
+	}
+
+	// Check the first argument.
+	argsNode := node.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return
+	}
+	firstArg := getNthChild(argsNode, 0)
+	if firstArg == nil {
+		return
+	}
+
+	// If the query string is built unsafely, report an issue.
+	if isUnsafeString(firstArg, source) {
+		pass.Report(pass, node, "Direct use of unsafe string in SQL query")
+		return
+	}
+
+	// If the argument is an identifier, trace its origin.
+	if firstArg.Type() == "identifier" {
+		varName := firstArg.Content(source)
+		traceVariableOrigin(pass, varName, node, make(map[string]bool), make(map[string]bool), source)
+	}
+}
+
+// isSQLExecuteMethod returns true if the function node is one of the SQL execution methods.
+func isSQLExecuteMethod(node *sitter.Node, source []byte) bool {
+	var funcName string
+	switch node.Type() {
+	case "identifier":
+		funcName = node.Content(source)
+	case "attribute":
+		attr := node.ChildByFieldName("attribute")
+		if attr != nil {
+			funcName = attr.Content(source)
+		}
+	}
+
+	sqlMethods := map[string]bool{
+		"execute":       true,
+		"executemany":   true,
+		"executescript": true,
+	}
+	return sqlMethods[funcName]
+}
+
+// isUnsafeString returns true if the node represents an unsafely built string (e.g. f-string interpolation or unsafe concatenation).
+func isUnsafeString(node *sitter.Node, source []byte) bool {
+	// Check for f-strings with interpolation.
+	if node.Type() == "fstring" {
+		for i := 0; i < int(node.ChildCount()); i++ {
+			if node.Child(i).Type() == "interpolation" {
+				return true
+			}
+		}
+	}
+
+	// Check for unsafe binary concatenation.
+	if node.Type() == "binary_operator" {
+		op := node.ChildByFieldName("operator")
+		if op != nil && op.Content(source) == "+" {
+			return containsVariable(node.ChildByFieldName("left"), source) ||
+				containsVariable(node.ChildByFieldName("right"), source)
+		}
+	}
+
+	return false
+}
+
+// traceVariableOrigin recursively traces the origin of a variable through local assignments and cross‐file imports.
+func traceVariableOrigin(pass *analysis.Pass, varName string, originalNode *sitter.Node,
+	visitedVars map[string]bool, visitedFiles map[string]bool, source []byte) {
+
+	if visitedVars[varName] {
+		return
+	}
+	visitedVars[varName] = true
+
+	if traceLocalAssignments(pass, varName, originalNode, visitedVars, visitedFiles, source) {
+		return
+	}
+
+	traceCrossFileImports(pass, varName, originalNode, visitedVars, visitedFiles, source)
+}
+
+// traceLocalAssignments looks for local assignments to the variable and reports if it originates from an unsafe string.
+func traceLocalAssignments(pass *analysis.Pass, varName string, originalNode *sitter.Node,
+	visitedVars map[string]bool, visitedFiles map[string]bool, source []byte) bool {
+
+	query := `(assignment left: (identifier) @var right: (_) @value)`
+	q, err := sitter.NewQuery([]byte(query), pass.Analyzer.Language.Parser())
+	if err != nil {
+		return false
+	}
+	defer q.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+	cursor.Exec(q, pass.FileContext.Ast)
+
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+
+		var varNode, valueNode *sitter.Node
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "var":
+				varNode = capture.Node
+			case "value":
+				valueNode = capture.Node
+			}
+		}
+
+		if varNode != nil && varNode.Content(source) == varName {
+			if isUnsafeString(valueNode, source) {
+				pass.Report(pass, originalNode, fmt.Sprintf("Variable '%s' originates from an unsafe string", varName))
+				return true
+			}
+
+			if valueNode.Type() == "identifier" {
+				newVar := valueNode.Content(source)
+				traceVariableOrigin(pass, newVar, originalNode, visitedVars, visitedFiles, source)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// traceCrossFileImports looks for import-from statements to trace the variable across files.
+func traceCrossFileImports(pass *analysis.Pass, varName string, originalNode *sitter.Node,
+	visitedVars map[string]bool, visitedFiles map[string]bool, source []byte) {
+
+	query := `(
+		(import_from_statement
+			module_name: (dotted_name) @module
+			name: (dotted_name) @imported_var
+		) @import
+	)`
+	q, err := sitter.NewQuery([]byte(query), pass.Analyzer.Language.Parser())
+	if err != nil {
+		return
+	}
+	defer q.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+	cursor.Exec(q, pass.FileContext.Ast)
+
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+
+		var moduleNode, varNode *sitter.Node
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "module":
+				moduleNode = capture.Node
+			case "imported_var":
+				varNode = capture.Node
+			}
+		}
+
+		if varNode != nil && varNode.Content(source) == varName && moduleNode != nil {
+			modulePath := convertImportToPath(moduleNode.Content(source))
+			if visitedFiles[modulePath] {
+				continue
+			}
+			visitedFiles[modulePath] = true
+
+			for _, file := range pass.Files {
+				if strings.HasSuffix(file.FilePath, modulePath) {
+					newPass := &analysis.Pass{
+						Analyzer:    pass.Analyzer,
+						FileContext: file,
+						Files:       pass.Files,
+						Report:      pass.Report,
+					}
+					traceVariableOrigin(newPass, varName, originalNode, visitedVars, visitedFiles, file.Source)
+				}
+			}
+		}
+	}
+}
+
+// containsVariable returns true if the node (or any of its subnodes) is an identifier or attribute.
+func containsVariable(node *sitter.Node, source []byte) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Type() {
+	case "identifier", "attribute":
+		return true
+	case "binary_operator":
+		return containsVariable(node.ChildByFieldName("left"), source) ||
+			containsVariable(node.ChildByFieldName("right"), source)
+	case "parenthesized_expression":
+		return containsVariable(node.NamedChild(0), source)
+	default:
+		return false
+	}
+}
+
+// getNthChild returns the nth child of a node or nil if out of bounds.
+func getNthChild(node *sitter.Node, n int) *sitter.Node {
+	if n < int(node.ChildCount()) {
+		return node.Child(n)
+	}
+	return nil
+}
+
+// convertImportToPath converts a dotted module name to a file path (e.g. "a.b" -> "a/b.py").
+func convertImportToPath(importStr string) string {
+	return strings.ReplaceAll(importStr, ".", string(filepath.Separator)) + ".py"
+}
+
+//everything beyond this point is a test
+
+func main() {
+	// Create a slice of analyzers. In this case, we include the SQLInjection analyzer.
+	analyzers := []*analysis.Analyzer{
+		SQLInjection(),
+	}
+
+	// Run the analyzers on the specified directory.
+	issues, err := analysis.RunAnalyzers("./afile.py", analyzers)
+	if err != nil {
+		fmt.Println("Error running analyzers:", err)
+		os.Exit(1)
+	}
+
+	// Optionally, report the issues in text format.
+	output, err := analysis.ReportIssues(issues, "text")
+	if err != nil {
+		fmt.Println("Error reporting issues:", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(output))
+}

--- a/checkers/python/avoid-unsanitized-sql.go
+++ b/checkers/python/avoid-unsanitized-sql.go
@@ -272,6 +272,7 @@ func convertImportToPath(importStr string) string {
 
 func main() {
 	// Create a slice of analyzers. In this case, we include the SQLInjection analyzer.
+	fmt.Println("print if ever executed")
 	analyzers := []*analysis.Analyzer{
 		SQLInjection(),
 	}

--- a/checkers/python/avoid-unsanitized-sql.go
+++ b/checkers/python/avoid-unsanitized-sql.go
@@ -2,7 +2,6 @@ package python
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -266,29 +265,4 @@ func getNthChild(node *sitter.Node, n int) *sitter.Node {
 // convertImportToPath converts a dotted module name to a file path (e.g. "a.b" -> "a/b.py").
 func convertImportToPath(importStr string) string {
 	return strings.ReplaceAll(importStr, ".", string(filepath.Separator)) + ".py"
-}
-
-//everything beyond this point is a test
-
-func main() {
-	// Create a slice of analyzers. In this case, we include the SQLInjection analyzer.
-	fmt.Println("print if ever executed")
-	analyzers := []*analysis.Analyzer{
-		SQLInjection(),
-	}
-
-	// Run the analyzers on the specified directory.
-	issues, err := analysis.RunAnalyzers("./afile.py", analyzers)
-	if err != nil {
-		fmt.Println("Error running analyzers:", err)
-		os.Exit(1)
-	}
-
-	// Optionally, report the issues in text format.
-	output, err := analysis.ReportIssues(issues, "text")
-	if err != nil {
-		fmt.Println("Error reporting issues:", err)
-		os.Exit(1)
-	}
-	fmt.Println(string(output))
 }

--- a/checkers/python/avoid-unsanitized-sql.test.py
+++ b/checkers/python/avoid-unsanitized-sql.test.py
@@ -8,16 +8,35 @@ app = FastAPI()
 def execute_unsafe_query(query: str):
     conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
-    cursor.execute(query)  # ✅ Uses parameterized query
+    cursor.execute(query)  #unsafe with user input
     result = cursor.fetchall()
     conn.commit()
     conn.close()
     return result
 
+def better_query(query: str, params):
+    conn = sqlite3.connect("test.db")
+    cursor = conn.cursor()
+    cursor.execute(query, params) #safe to execute with user input
+    result = cursor.fetchall()
+    conn.commit()
+    conn.close()
+    return result
+
+
 @app.get("/unsafe_query/")
 def unsafe_query(user_input: str):
+    #f-string case
+    #<expect-error>
     query = f"SELECT * FROM users WHERE name = {user_input}"
+    #binary operator case
+    #<expect-error>
     query2= "SELECT * FROM users WHERE name ="+ user_input
+    #should not identify this as an error
+    query3= "SELECT * FROM user WHERE name= ?"
     result = execute_unsafe_query(query)
     result2= execute_unsafe_query(query=query2)
-    return {"result": result, "result2": result2}
+
+    result3= better_query(query=query3, params=(user_input,))
+
+    return {"result": result, "result2": result2, "result3": result3}

--- a/checkers/python/avoid-unsanitized-sql.test.py
+++ b/checkers/python/avoid-unsanitized-sql.test.py
@@ -8,6 +8,7 @@ app = FastAPI()
 def execute_unsafe_query(query: str):
     conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
+    #<expect-error>
     cursor.execute(query)  #unsafe with user input
     result = cursor.fetchall()
     conn.commit()
@@ -27,11 +28,12 @@ def better_query(query: str, params):
 @app.get("/unsafe_query/")
 def unsafe_query(user_input: str):
     #f-string case
-    #<expect-error>
+    
     query = f"SELECT * FROM users WHERE name = {user_input}"
     #binary operator case
-    #<expect-error>
+
     query2= "SELECT * FROM users WHERE name ="+ user_input
+    
     #should not identify this as an error
     query3= "SELECT * FROM user WHERE name= ?"
     result = execute_unsafe_query(query)

--- a/checkers/python/avoid-unsanitized-sql.test.py
+++ b/checkers/python/avoid-unsanitized-sql.test.py
@@ -1,0 +1,23 @@
+
+import sqlite3
+from fastapi import FastAPI, Query
+import sqlite3
+
+app = FastAPI()
+
+def execute_unsafe_query(query: str):
+    conn = sqlite3.connect("test.db")
+    cursor = conn.cursor()
+    cursor.execute(query)  # ✅ Uses parameterized query
+    result = cursor.fetchall()
+    conn.commit()
+    conn.close()
+    return result
+
+@app.get("/unsafe_query/")
+def unsafe_query(user_input: str):
+    query = f"SELECT * FROM users WHERE name = {user_input}"
+    query2= "SELECT * FROM users WHERE name ="+ user_input
+    result = execute_unsafe_query(query)
+    result2= execute_unsafe_query(query=query2)
+    return {"result": result, "result2": result2}

--- a/checkers/python/testdata/avoid-unsanitized-sql.test.py
+++ b/checkers/python/testdata/avoid-unsanitized-sql.test.py
@@ -1,0 +1,41 @@
+import sqlite3
+from fastapi import FastAPI, Query
+import sqlite3
+
+app = FastAPI()
+
+def execute_unsafe_query(query: str):
+    conn = sqlite3.connect("test.db")
+    cursor = conn.cursor()
+    cursor.execute(query)  #unsafe with user input
+    result = cursor.fetchall()
+    conn.commit()
+    conn.close()
+    return result
+
+def better_query(query: str, params):
+    conn = sqlite3.connect("test.db")
+    cursor = conn.cursor()
+    cursor.execute(query, params) #safe to execute with user input
+    result = cursor.fetchall()
+    conn.commit()
+    conn.close()
+    return result
+
+
+@app.get("/unsafe_query/")
+def unsafe_query(user_input: str):
+    #f-string case
+    #<expect-error>
+    query = f"SELECT * FROM users WHERE name = {user_input}"
+    #binary operator case
+    #<expect-error>
+    query2= "SELECT * FROM users WHERE name ="+ user_input
+    #should not identify this as an error
+    query3= "SELECT * FROM user WHERE name= ?"
+    result = execute_unsafe_query(query)
+    result2= execute_unsafe_query(query=query2)
+
+    result3= better_query(query=query3, params=(user_input,))
+
+    return {"result": result, "result2": result2, "result3": result3}

--- a/checkers/python/testdata/avoid-unsanitized-sql.test.py
+++ b/checkers/python/testdata/avoid-unsanitized-sql.test.py
@@ -7,6 +7,7 @@ app = FastAPI()
 def execute_unsafe_query(query: str):
     conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
+    #<expect-error>
     cursor.execute(query)  #unsafe with user input
     result = cursor.fetchall()
     conn.commit()
@@ -26,10 +27,10 @@ def better_query(query: str, params):
 @app.get("/unsafe_query/")
 def unsafe_query(user_input: str):
     #f-string case
-    #<expect-error>
+    
     query = f"SELECT * FROM users WHERE name = {user_input}"
     #binary operator case
-    #<expect-error>
+    
     query2= "SELECT * FROM users WHERE name ="+ user_input
     #should not identify this as an error
     query3= "SELECT * FROM user WHERE name= ?"


### PR DESCRIPTION
### Description:
GoLang was chosen for this checker for complex logical control of flow of execution.
#### Basic Idea:
SQL injection vulnerability in this checker is assumed when a SQL query contains concatenated string (f-string or interpolation) with user-input instead of parameterisation.
#### Logic:
To identify an SQL execution call, we search for the most common execution calls across all SQL libraries and ORMs, like:
execute, executemany, executescript
Once we find such a call, the first case we check for, is if the developer has passed a string directly to the execution call, in which case, a normal tree-sitter-query is enough.
If instead, we find a variable passed as parameter, instead of raw string, we use Go to trace the variable back to it's origin, whether it's in the same file or in a different file in the same project (hence, accounting for multiple layers of variables being passed in one another).
Once spotted, we check the assigned value for any concatenated strings. If found, the user receives Report.

## Type Of Change
- [x] New Checker

## Checklist:
- [x] All required checkers added
- [x] Test case added
- [ ] Not tested (since current Github Actions workflow does not have support for testing Go checkers, as per test_runner.go)