### PR TITLE
PHP echo/print unsanitized user input

### DIFF
--- a/checkers/php/dangerous-unsanitized-input.test.php
+++ b/checkers/php/dangerous-unsanitized-input.test.php
@@ -1,0 +1,89 @@
+<?php
+// XSS Vulnerability Test File
+function test_echo_direct_unsanitized()
+{
+    // Vulnerable: User input is output directly.
+    // <except-error>
+    echo $_GET["input"];
+}
+
+// function test_echo_concatenation()
+// {
+//     // Vulnerable: Concatenates unsanitized input into a greeting.
+//     // <except-error>
+//     echo "Hello, " . $_POST["username"] . "!";
+// }
+
+function test_print_unsanitized()
+{
+    // Vulnerable: Directly prints unsanitized user data.
+    // <except-error>
+    print $_REQUEST["data"];
+}
+
+function test_html_attribute_injection()
+{
+    // Vulnerable: Unsanitized URL injected into an anchor tag.
+    // <except-error>
+    echo '<a href="' . $_GET["url"] . '">Click Here</a>';
+}
+
+function test_input_field_unsanitized()
+{
+    // Vulnerable: The value attribute is populated without encoding.
+    // <except-error>
+    echo '<input type="text" value="' . $_GET["value"] . '">';
+}
+
+function test_script_block_unsanitized()
+{
+    // Vulnerable: User input is embedded directly in a script.
+    // <except-error>
+    echo "<script>";
+    echo 'var userInput = "' . $_GET["jsdata"] . '";';
+    echo "alert(userInput);";
+    echo "</script>";
+}
+
+function test_double_quote_array_access()
+{
+    // Vulnerable: Functionally similar to single quotes; unsanitized input is echoed.
+    // <except-error>
+    echo $_GET["param"];
+}
+
+function test_dom_manipulation()
+{
+    // Vulnerable: User content is injected into both HTML and JavaScript contexts.
+    // <except-error>
+    echo '<div id="output">' . $_GET["content"] . "</div>";
+    echo '<script>document.getElementById("output").innerHTML = "' .
+        $_GET["content"] .
+        '";</script>';
+}
+
+// Safer usage of echo and print
+function test_safe_echo()
+{
+    // no error should be reported
+    echo htmlspecialchars($_GET["input"], ENT_QUOTES, "UTF-8");
+}
+
+function test_safe_filter_var()
+{
+    // no error should be reported
+    $safe_url = filter_var($_GET["url"], FILTER_SANITIZE_URL);
+    echo '<a href="' .
+        htmlspecialchars($safe_url, ENT_QUOTES, "UTF-8") .
+        '">Click Here</a>';
+}
+
+function test_safe_json_encode()
+{
+    // no error should be reported
+    echo "<script>";
+    echo "var userInput = " . json_encode($_GET["jsdata"]) . ";";
+    echo "alert(userInput);";
+    echo "</script>";
+}
+?>

--- a/checkers/php/dangerous-unsanitized-input.yml
+++ b/checkers/php/dangerous-unsanitized-input.yml
@@ -1,0 +1,76 @@
+language: php
+name: unsanitized_input_handling
+message: "Possible XSS vulnerability detected. Ensure user input is properly validated and output is encoded."
+category: security
+severity: critical
+
+pattern: >
+  (
+    (echo_statement
+      (subscript_expression
+      	(variable_name) @user_input )
+      (#match? @user_input "^(\\$_GET|\\$_POST|\\$_REQUEST|\\$_COOKIE|\\$_SERVER)")
+    )) @vuln_echo
+
+  (
+    (print_intrinsic
+      (subscript_expression
+      	(variable_name) @user_input)
+      (#match? @user_input "^(\\$_GET|\\$_POST|\\$_REQUEST|\\$_COOKIE|\\$_SERVER)")
+    )) @vuln_print
+
+  (
+    (echo_statement
+      (binary_expression
+        right: (variable_name) @user_input
+        (#match? @user_input "^(\\$_GET|\\$_POST|\\$_REQUEST|\\$_COOKIE|\\$_SERVER)")
+      )
+    )) @vuln_html_attr
+
+  (
+    (echo_statement
+      (binary_expression
+        right: (variable_name) @user_input
+        (#match? @user_input "^(\\$_GET|\\$_POST|\\$_REQUEST|\\$_COOKIE|\\$_SERVER)")
+      )
+    )) @vuln_js_inject
+
+exclude:
+  - "**/vendor/**"
+  - "**/tests/**"
+
+description: |
+  description: |
+    Issue:
+      Outputting unsanitized user input without escaping special HTML characters can lead to Cross-Site Scripting (XSS), a critical security vulnerability. This occurs when user-controlled data is directly embedded into the page without proper encoding or sanitization.
+
+    Risk:
+      Directly printing $_GET, $_POST, $_COOKIE, or other user-controlled input without escaping allows attackers to inject malicious scripts. This can result in:
+        - Theft of sensitive user data, including session cookies and login credentials.
+        - Defacement or manipulation of the webpage.
+        - Execution of unauthorized actions on behalf of authenticated users (Session Hijacking).
+
+    Example Attack:
+      Consider the following insecure PHP code:
+
+      ```php
+      <?php echo $_GET['q']; ?>
+      ```
+
+      If accessed with a URL like `?q=<script>alert(1)</script>`, the injected script will execute in the victim's browser, potentially compromising security.
+
+    Security Measures:
+      To prevent XSS attacks, implement proper input sanitization and output encoding techniques:
+
+      1. Escape Output Properly:
+         - Use `htmlspecialchars($_GET['q'], ENT_QUOTES, 'UTF-8');` to escape HTML characters before rendering output.
+         - If the input is intended for use in JavaScript, use `json_encode($_GET['q']);`.
+
+      2. Input Validation:
+         - Restrict the accepted input format using validation functions like:
+           ```php
+           filter_input(INPUT_GET, 'q', FILTER_SANITIZE_STRING);
+           ```
+         - Use allowlists (whitelists) for expected values instead of relying on blacklists.
+
+    By following these best practices, applications can significantly reduce the risk of XSS vulnerabilities and ensure a secure web environment.


### PR DESCRIPTION
**Issue:**
Outputting unsanitized user input without escaping special HTML characters can lead to Cross-Site Scripting (XSS), a critical security vulnerability. This occurs when user-controlled data is directly embedded into the page without proper encoding or sanitization.

**Risk:**
Directly printing $_GET, $_POST, $_COOKIE, or other user-controlled input without escaping allows attackers to inject malicious scripts. This can result in:

Theft of sensitive user data, including session cookies and login credentials.
Defacement or manipulation of the webpage.
Execution of unauthorized actions on behalf of authenticated users (Session Hijacking).
Example Attack:
Consider the following insecure PHP code:

`<?php echo $_GET['q']; ?>`

If accessed with a URL like `?q=<script>alert(1)</script>`, the injected script will execute in the victim's browser, potentially compromising security.

Security Measures:
To prevent XSS attacks, implement proper input sanitization and output encoding techniques:

**Escape Output Properly:**

Use htmlspecialchars($_GET['q'], ENT_QUOTES, 'UTF-8'); to escape HTML characters before rendering output.
If the input is intended for use in JavaScript, use json_encode($_GET['q']);.
Input Validation:

Restrict the accepted input format using validation functions like filter_input(INPUT_GET, 'q', FILTER_SANITIZE_STRING);.
Use allowlists (whitelists) for expected values instead of relying on blacklists.
Content Security Policy (CSP):

Employ frameworks and security libraries that handle escaping and sanitization automatically.
If using Twig or Blade templates, leverage built-in escaping mechanisms.
