### PR TITLE
chore: add checker to detect globals context in django render method

### DIFF
--- a/checkers/python/globals-as-template-context.test.py
+++ b/checkers/python/globals-as-template-context.test.py
@@ -1,0 +1,30 @@
+import base64
+import mimetypes
+import os
+
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.shortcuts import redirect, render
+from django.views.decorators.csrf import csrf_exempt
+from django.template import Template
+
+# adapted from https://github.com/mpirnat/lets-be-bad-guys/blob/7cbf11014bfc6dc9e199dc0b8a64e4597bc2338f/badguys/vulnerable/views.py#L95
+
+def file_access(request):
+    msg = request.GET.get('msg', '')
+    # <no-error>
+    return render(request, 'vulnerable/injection/file_access.html',
+            {'msg': msg})
+
+
+def bad1(request):
+    # <expect-error>
+    response = render(request, 'vulnerable/xss/form.html', globals())
+    response.set_cookie(key='monster', value='omnomnomnomnom!')
+    return response
+
+def bad3(request):
+    # <expect-error>
+    response = Template.render(request, 'vulnerable/xss/form.html', globals())
+    response.set_cookie(key='monster', value='omnomnomnomnom!')
+    return response

--- a/checkers/python/globals-as-template-context.yml
+++ b/checkers/python/globals-as-template-context.yml
@@ -1,0 +1,34 @@
+language: py
+name: globals-as-template-context
+message: Detected the usage of `globals()` as context to `render()`
+category: security
+severity: error
+
+pattern: |
+  (call
+    function: (identifier) @render
+    arguments: (argument_list
+      (_)*
+      (call
+        function: (identifier) @globals
+        arguments: (argument_list))
+      (_)*)
+    (#eq? @render "render")
+    (#eq? @globals "globals")) @globals-as-template-context
+
+  (call
+    function: (attribute
+      object: (identifier) @template
+      attribute: (identifier) @render)
+    arguments: (argument_list
+      (_)*
+      (call
+        function: (identifier) @globals
+        arguments: (argument_list))
+      (_)*)
+    (#eq? @template "Template")
+    (#eq? @render "render")
+    (#eq? @globals "globals")) @globals-as-template-context
+
+description: |
+  Using globals() in render(...) is dangerous—it exposes unintended Python functions, leading to server-side template injection (SSTI). Attackers could execute arbitrary code. Instead, pass only the required variables in a dictionary or `django.template.Context`.


### PR DESCRIPTION
Test logs:

```
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: globals-as-template-context.yml
Running test case: safe-string-extend.yml
All tests passed%                    
```