### PR TITLE
chore: add checker to detect 'none' algo in JWT token encode/decode method

### DIFF
--- a/checkers/python/jwt-python-none-alg.test.py
+++ b/checkers/python/jwt-python-none-alg.test.py
@@ -1,0 +1,16 @@
+import jwt
+
+def bad1():
+    # <expect-error>
+    encoded = jwt.encode({'some': 'payload'}, None, algorithm='none')
+    return encoded
+
+def bad2(encoded):
+    # <expect-error>
+    jwt.decode(encoded, None, algorithms=['none'])
+    return encoded
+
+def ok(secret_key):
+    # <no-error>
+    encoded = jwt.encode({'some': 'payload'}, secret_key, algorithm='HS256')
+    return encoded

--- a/checkers/python/jwt-python-none-alg.test.py
+++ b/checkers/python/jwt-python-none-alg.test.py
@@ -1,9 +1,13 @@
 import jwt
 
+# adapted from
+# - https://github.com/Shopify/shopify_python_api/blob/main/test/session_token_test.py#L59
+# - https://github.com/flipkart-incubator/Astra/blob/master/modules/jwt_attack.py#L37
 def bad1():
     # <expect-error>
     encoded = jwt.encode({'some': 'payload'}, None, algorithm='none')
     return encoded
+
 
 def bad2(encoded):
     # <expect-error>

--- a/checkers/python/jwt-python-none-alg.yml
+++ b/checkers/python/jwt-python-none-alg.yml
@@ -1,0 +1,42 @@
+language: py
+name: jwt-python-none-alg
+message: Detected the usage of `none` in the algorithms parameter in JWT token
+category: security
+
+pattern: |
+  (call
+    function: (attribute
+      object: (identifier) @jwt
+      attribute: (identifier) @encode)
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @algorithm
+        value: (string
+          (string_content) @none))
+      (_)*)
+    (#eq? @jwt "jwt")
+    (#eq? @encode "encode")
+    (#eq? @algorithm "algorithm")
+    (#eq? @none "none")) @jwt-python-none-alg
+
+  
+  (call
+    function: (attribute
+      object: (identifier) @jwt
+      attribute: (identifier) @decode)
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @algorithms
+        value: (list
+          (string
+            (string_content) @none)))
+      (_)*)
+    (#eq? @jwt "jwt")
+    (#eq? @decode "decode")
+    (#eq? @algorithms "algorithms")
+    (#eq? @none "none")) @jwt-python-none-alg
+
+desciption: |
+  The JWT token uses the 'none' algorithm, which assumes its integrity is already verified. This allows attackers to forge tokens that get automatically verified. Avoid using 'none'; use a secure algorithm like 'HS256' instead.

--- a/checkers/python/jwt-python-none-alg.yml
+++ b/checkers/python/jwt-python-none-alg.yml
@@ -1,6 +1,6 @@
 language: py
 name: jwt-python-none-alg
-message: Detected the usage of `none` in the algorithms parameter in JWT token
+message: Do not use `none` algorithm for encoding/decoding JWT tokens
 category: security
 
 pattern: |


### PR DESCRIPTION
Test logs

```
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: jwt-python-none-alg.yml
Running test case: safe-string-extend.yml
All tests passed%                  
```