### PR TITLE
docker: avoid the use of `latest` tag

### DIFF
--- a/checkers/docker/avoid_latest.test.Dockerfile
+++ b/checkers/docker/avoid_latest.test.Dockerfile
@@ -1,0 +1,26 @@
+## test_unsafe: These should be flagged
+
+# <expect-error>
+FROM ubuntu:latest
+
+# <expect-error>
+FROM node:latest
+
+# <expect-error>
+FROM python:latest
+
+# <expect-error>
+FROM alpine:latest AS builder
+
+
+## test_safe: These are safe and should not be flagged
+
+# Using a specific version
+FROM ubuntu:20.04
+
+FROM python:3.10
+
+FROM alpine:3.17 AS builder
+
+# Should not flag comments containing "latest"
+# FROM image:latest

--- a/checkers/docker/avoid_latest.yml
+++ b/checkers/docker/avoid_latest.yml
@@ -1,6 +1,6 @@
 language: dockerfile
 name: avoid_latest
-message: "Avoid using the 'latest' tag in Dockerfiles, use a specific version to ensure reliability"
+message: "Avoid using the 'latest' tag, use a specific version instead"
 category: bug-risk
 severity: warning
 

--- a/checkers/docker/avoid_latest.yml
+++ b/checkers/docker/avoid_latest.yml
@@ -1,0 +1,19 @@
+language: dockerfile
+name: avoid_latest
+message: "Avoid using the 'latest' tag in Dockerfiles, use a specific version to ensure reliability"
+category: bug-risk
+severity: warning
+
+pattern: |
+ (from_instruction
+  (image_spec
+    name: (image_name)
+    tag: (image_tag) @image_tag
+     (#eq? @image_tag ":latest")
+  )
+ ) @avoid_latest
+
+description: |
+ Using the 'latest' tag for docker images can lead to non-reproducible builds and unexpected behavior,
+ this is because 'latest' may point to different versions over time. It's recommended to specify a
+ version tag to ensure consistency and prevent unexpected changes.


### PR DESCRIPTION
## 📌 Summary  
This PR introduces a new rule to detect and warn against the use of the `latest` tag in Docker images. Since the `latest` tag can point to different versions of the image over time, it can lead to non-reproducible builds and unexpected changes. This rule encourages specifying a fixed version to ensure reliability.  

A stack overflow answer on the topic: [link](https://stackoverflow.com/questions/72889955/is-it-bad-practice-to-use-mysqllatest-as-docker-image)
## ✅ Example  
### 🚨 **Flagged**  
```dockerfile
FROM python:latest
