### PR TITLE
docker: avoid the use of the `ADD` instruction

### DIFF
--- a/checkers/docker/avoid_add.test.Dockerfile
+++ b/checkers/docker/avoid_add.test.Dockerfile
@@ -1,0 +1,26 @@
+## These should be flagged
+
+# <expect-error>
+ADD ./source /destination
+
+# <expect-error>
+ADD https://example.com/file.tar.gz /destination/
+
+# <expect-error>
+ADD archive.tar.gz /extract-here/
+
+# <expect-error>
+ADD ["file1", "file2", "/dest/"]
+
+# <expect-error>
+ADD --chown=1000:1000 sourcefile /destination/
+
+## These are safe and should not be flagged
+
+# Using COPY instead of ADD
+COPY ./source /destination
+
+COPY ["file1", "file2", "/dest/"]
+
+# Comments containing "ADD" should not trigger detection
+# This is an example: ADD should not be used

--- a/checkers/docker/avoid_add.yml
+++ b/checkers/docker/avoid_add.yml
@@ -1,0 +1,13 @@
+language: dockerfile
+name: avoid_add
+message: "Avoid using the 'ADD' instruction in Dockerfiles, prefer 'COPY' instead for copying files"
+category: antipattern
+severity: warning
+
+pattern: |
+  (add_instruction) @avoid_add
+
+description: |
+  The 'ADD' instruction in Dockerfiles should be avoided due to its unintended side effects,
+  such as automatic archive extraction and remote URL downloads, which can introduce security risks.
+  If you only need to copy files into the image, prefer the use of 'COPY'.

--- a/checkers/docker/avoid_add.yml
+++ b/checkers/docker/avoid_add.yml
@@ -1,6 +1,6 @@
 language: dockerfile
 name: avoid_add
-message: "Avoid using the 'ADD' instruction in Dockerfiles, prefer 'COPY' instead for copying files"
+message: "Avoid using the 'ADD' instruction, prefer 'COPY' instead for copying files"
 category: antipattern
 severity: warning
 


### PR DESCRIPTION
## 📌 Summary  
This PR adds a checker to detect the use of the `ADD` instruction in Dockerfiles; If used for copying files `ADD` has certain side effects, for example - The ability to do automatic archive extraction and remote URL downloads which can introduce security risks. This checker warns the user and tells them to prefer the `COPY` instruction instead.

See - [Dockerfile Best Practices](https://cloudberry.engineering/article/dockerfile-security-best-practices/)

## ✅ Example  
### 🚨 **Flagged**  
```dockerfile
ADD https://example.com/file.tar.gz /destination/
```