### PR TITLE
go: weak scrypt cost

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	goAnalysis "globstar.dev/analysis"
+	"globstar.dev/checkers/golang"
 	"globstar.dev/checkers/javascript"
 	"globstar.dev/pkg/analysis"
 )
@@ -51,5 +52,6 @@ func LoadYamlRules() (map[analysis.Language][]analysis.YmlRule, error) {
 func LoadGoRules() []*goAnalysis.Analyzer {
 	return []*goAnalysis.Analyzer{
 		&javascript.NoDoubleEq,
+		&golang.WeakScryptCost,
 	}
 }

--- a/checkers/golang/weak_scrypt_cost.go
+++ b/checkers/golang/weak_scrypt_cost.go
@@ -1,0 +1,71 @@
+package golang
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var WeakScryptCost analysis.Analyzer = analysis.Analyzer{
+	Name:        "weak-scrypt-cost",
+	Language:    analysis.LangGo,
+	Description: "This rule checks for scrypt usage with N parameter less than 32768.",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityWarning,
+	Run:         weakScryptCost,
+}
+
+func weakScryptCost(pass *analysis.Pass) (interface{}, error) {
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "call_expression" {
+			return
+		}
+
+		function := node.ChildByFieldName("function")
+		if function == nil || function.Type() != "selector_expression" {
+			return
+		}
+
+		operand := function.ChildByFieldName("operand")
+		field := function.ChildByFieldName("field")
+		if operand == nil || field == nil {
+			return
+		}
+
+		source := pass.FileContext.Source
+		if operand.StartByte() >= uint32(len(source)) || operand.EndByte() > uint32(len(source)) {
+			return
+		}
+		if field.StartByte() >= uint32(len(source)) || field.EndByte() > uint32(len(source)) {
+			return
+		}
+
+		operandContent := string(source[operand.StartByte():operand.EndByte()])
+		fieldContent := string(source[field.StartByte():field.EndByte()])
+
+		if operandContent == "scrypt" && fieldContent == "Key" {
+			arguments := node.ChildByFieldName("arguments")
+			if arguments == nil || arguments.Type() != "argument_list" || arguments.NamedChildCount() < 6 {
+				return
+			}
+
+			// N parameter is the 3rd argument (index 2)
+			nNode := arguments.NamedChild(2)
+			if nNode == nil || nNode.StartByte() >= uint32(len(source)) || nNode.EndByte() > uint32(len(source)) {
+				return
+			}
+
+			nContent := string(source[nNode.StartByte():nNode.EndByte()])
+			n, err := strconv.ParseInt(nContent, 10, 64)
+			if err != nil {
+				return
+			}
+
+			if n < 32768 {
+				pass.Report(pass, node, "scrypt: N parameter should be ≥ 32768 (detected "+nContent+")")
+			}
+		}
+	})
+	return nil, nil
+}

--- a/checkers/golang/weak_scrypt_cost.test.go
+++ b/checkers/golang/weak_scrypt_cost.test.go
@@ -1,0 +1,31 @@
+package golang
+
+import (
+	"crypto/rand"
+)
+
+// Mock implementations to test analyzer detection
+type scryptMock struct{}
+
+func (s *scryptMock) Key(password, salt []byte, N, r, p, keyLen int) ([]byte, error) {
+	return nil, nil
+}
+
+func testScryptCost() {
+	var (
+		scrypt scryptMock
+	)
+
+	// <expect-error>
+	scrypt.Key([]byte("password"), makeRandomSalt(), 16384, 8, 1, 32)
+
+	// Valid examples (no errors)
+	// <no-error>
+	scrypt.Key([]byte("password"), makeRandomSalt(), 32768, 8, 1, 32)
+}
+
+func makeRandomSalt() []byte {
+	salt := make([]byte, 16)
+	rand.Read(salt)
+	return salt
+}


### PR DESCRIPTION
### Description

This checker detects the usage of `scrypt.Key` with an `N` parameter (CPU/memory cost parameter) less than 32768. The scrypt algorithm is designed to be memory-hard, making it resistant to brute-force attacks, especially those using custom hardware. A low `N` parameter reduces the memory and CPU cost, making it easier for attackers to crack passwords. This checker is flagged as a security warning to ensure `scrypt` is configured with a sufficiently high `N` parameter.

### Recommendation

Use an N parameter of 32768 or higher when calling `scrypt.Key`.