### PR TITLE
go: weak pbkdf2 iterations

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	goAnalysis "globstar.dev/analysis"
+	"globstar.dev/checkers/golang"
 	"globstar.dev/checkers/javascript"
 	"globstar.dev/pkg/analysis"
 )
@@ -51,5 +52,6 @@ func LoadYamlRules() (map[analysis.Language][]analysis.YmlRule, error) {
 func LoadGoRules() []*goAnalysis.Analyzer {
 	return []*goAnalysis.Analyzer{
 		&javascript.NoDoubleEq,
+		&golang.WeakPbkdf2Iterations,
 	}
 }

--- a/checkers/golang/weak_pbkdf2_iterations.go
+++ b/checkers/golang/weak_pbkdf2_iterations.go
@@ -1,0 +1,71 @@
+package golang
+
+import (
+	"strconv"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var WeakPbkdf2Iterations analysis.Analyzer = analysis.Analyzer{
+	Name:        "weak-pbkdf2-iterations",
+	Language:    analysis.LangGo,
+	Description: "This rule checks for PBKDF2 usage with fewer than 310,000 iterations.",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityWarning,
+	Run:         weakPbkdf2Iterations,
+}
+
+func weakPbkdf2Iterations(pass *analysis.Pass) (interface{}, error) {
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "call_expression" {
+			return
+		}
+
+		function := node.ChildByFieldName("function")
+		if function == nil || function.Type() != "selector_expression" {
+			return
+		}
+
+		operand := function.ChildByFieldName("operand")
+		field := function.ChildByFieldName("field")
+		if operand == nil || field == nil {
+			return
+		}
+
+		source := pass.FileContext.Source
+		if operand.StartByte() >= uint32(len(source)) || operand.EndByte() > uint32(len(source)) {
+			return
+		}
+		if field.StartByte() >= uint32(len(source)) || field.EndByte() > uint32(len(source)) {
+			return
+		}
+
+		operandContent := string(source[operand.StartByte():operand.EndByte()])
+		fieldContent := string(source[field.StartByte():field.EndByte()])
+
+		if operandContent == "pbkdf2" && fieldContent == "Key" {
+			arguments := node.ChildByFieldName("arguments")
+			if arguments == nil || arguments.Type() != "argument_list" || arguments.NamedChildCount() < 5 {
+				return
+			}
+
+			// Iterations is the 3rd argument (index 2)
+			iterNode := arguments.NamedChild(2)
+			if iterNode == nil || iterNode.StartByte() >= uint32(len(source)) || iterNode.EndByte() > uint32(len(source)) {
+				return
+			}
+
+			iterContent := string(source[iterNode.StartByte():iterNode.EndByte()])
+			iterations, err := strconv.ParseInt(iterContent, 10, 64)
+			if err != nil {
+				return
+			}
+
+			if iterations < 310000 {
+				pass.Report(pass, node, "PBKDF2: Use at least 310,000 iterations for security (OWASP 2023 recommendation)")
+			}
+		}
+	})
+	return nil, nil
+}

--- a/checkers/golang/weak_pbkdf2_iterations.go
+++ b/checkers/golang/weak_pbkdf2_iterations.go
@@ -10,7 +10,7 @@ import (
 var WeakPbkdf2Iterations analysis.Analyzer = analysis.Analyzer{
 	Name:        "weak-pbkdf2-iterations",
 	Language:    analysis.LangGo,
-	Description: "This rule checks for PBKDF2 usage with fewer than 310,000 iterations.",
+	Description: "This rule checks for PBKDF2 usage with fewer than 600,000 iterations.",
 	Category:    analysis.CategorySecurity,
 	Severity:    analysis.SeverityWarning,
 	Run:         weakPbkdf2Iterations,
@@ -62,8 +62,8 @@ func weakPbkdf2Iterations(pass *analysis.Pass) (interface{}, error) {
 				return
 			}
 
-			if iterations < 310000 {
-				pass.Report(pass, node, "PBKDF2: Use at least 310,000 iterations for security (OWASP 2023 recommendation)")
+			if iterations < 600000 {
+				pass.Report(pass, node, "PBKDF2: Use at least 600,000 iterations for security (OWASP recommendation)")
 			}
 		}
 	})

--- a/checkers/golang/weak_pbkdf2_iterations_test.go
+++ b/checkers/golang/weak_pbkdf2_iterations_test.go
@@ -1,0 +1,38 @@
+package golang
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"hash"
+)
+
+const fixedSalt = "INSECURE_CONSTANT"
+
+// Mock implementations to test analyzer detection
+type pbkdf2Mock struct{}
+
+func (p *pbkdf2Mock) Key(password, salt []byte, iter, keyLen int, h func() hash.Hash) []byte {
+	return nil
+}
+
+func testPbkdf2Iterations() {
+	var (
+		pbkdf2 pbkdf2Mock
+	)
+
+	// <expect-error>
+	pbkdf2.Key([]byte("password"), []byte(fixedSalt), 100000, 32, sha256.New)
+
+	// <expect-error>
+	pbkdf2.Key([]byte("password"), makeRandomSalt(), 250000, 32, sha256.New)
+
+	// Valid examples (no errors)
+	// <no-error>
+	pbkdf2.Key([]byte("password"), makeRandomSalt(), 310000, 32, sha256.New)
+}
+
+func makeRandomSalt() []byte {
+	salt := make([]byte, 16)
+	rand.Read(salt)
+	return salt
+}

--- a/checkers/golang/weak_pbkdf2_iterations_test.go
+++ b/checkers/golang/weak_pbkdf2_iterations_test.go
@@ -28,7 +28,7 @@ func testPbkdf2Iterations() {
 
 	// Valid examples (no errors)
 	// <no-error>
-	pbkdf2.Key([]byte("password"), makeRandomSalt(), 310000, 32, sha256.New)
+	pbkdf2.Key([]byte("password"), makeRandomSalt(), 600000, 32, sha256.New)
 }
 
 func makeRandomSalt() []byte {


### PR DESCRIPTION
### Description

This checker detects the usage of `pbkdf2.Key` with fewer than 600,000 iterations. PBKDF2 is a key derivation function that applies a pseudorandom function (like HMAC-SHA256) to the password along with a salt value multiple times to produce a more secure derived key. A low number of iterations reduces the computational effort, making it easier for attackers to crack passwords. This checker is flagged as a security warning to ensure PBKDF2 is configured with a sufficiently high number of iterations.

### Recommendation

Use at least 600,000 iterations when calling `pbkdf2.Key`. 