### PR TITLE
docker: avoid using `sudo` in RUN commands

### DIFF
--- a/checkers/docker/avoid_sudo.test.Dockerfile
+++ b/checkers/docker/avoid_sudo.test.Dockerfile
@@ -1,0 +1,13 @@
+## These should be flagged
+# <expect-error>
+RUN sudo apt-get update && apt-get install -y vim
+
+# <expect-error>
+RUN sudo -u username yum install -y wget
+
+# <expect-error>
+RUN sudo dd if=/dev/zero of=/dev/sda
+
+## These should not be flagged
+RUN apt-get update && apt-get install -y vim
+RUN yum install -y wget

--- a/checkers/docker/avoid_sudo.yml
+++ b/checkers/docker/avoid_sudo.yml
@@ -1,0 +1,18 @@
+language: dockerfile
+name: avoid_sudo
+message: "Avoid using 'sudo' in RUN commands; Dockerfiles execute commands as root by default"
+category: antipattern
+severity: warning
+
+pattern: |
+ (run_instruction
+  (shell_command
+    (shell_fragment) @sudo
+         (#match? @sudo "^(sudo)")
+  )
+ ) @avoid_sudo
+
+description: |
+  Using 'sudo' in 'RUN' commands within Dockerfiles is unnecessary as containers
+  run commands as the root user by default. Consider using a non-root user, without sudo,
+  as it reduces the risk of damage if the application is compromised.

--- a/checkers/docker/avoid_sudo.yml
+++ b/checkers/docker/avoid_sudo.yml
@@ -1,6 +1,6 @@
 language: dockerfile
 name: avoid_sudo
-message: "Avoid using 'sudo' in RUN commands; Dockerfiles execute commands as root by default"
+message: "Avoid using 'sudo' in RUN commands as Docker executes commands as root by default"
 category: antipattern
 severity: warning
 


### PR DESCRIPTION
## 📌 Summary  
This PR introduces a new rule to detect and warn against the use of `sudo` in `RUN` commands within Dockerfiles. Since Docker containers execute commands as the root user by default, using `sudo` is unnecessary.

The recommend approach is to define a non-root User and prevent the use of `sudo`. This will help prevent privilege escalation attacks. The checker for this would require an reverse-pattern though, see #126.

A relevant article on best practices: [Dockerfile Security Best Practices](https://cloudberry.engineering/article/dockerfile-security-best-practices)  

## ✅ Example  
### 🚨 **Flagged**  
```dockerfile
RUN sudo apt update && sudo apt install -y curl
RUN sudo rm -rf /
