### PR TITLE
feat: add more information to version subcommand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.PAT_GITHUB}}' >> .release-env
           echo 'HOMEBREW_TOKEN=${{secrets.DS_BOT_PAT}}' >> .release-env
+          echo "GOVERSION=$(go version | awk '{print $3}')" >> .release-env
 
       - name: Publish Release
         run: make release

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@ GOLANG_CROSS_VERSION  ?= v1.23
 SYSROOT_DIR     ?= sysroots
 SYSROOT_ARCHIVE ?= sysroots.tar.bz2
 
-CLI_BUILD_FLAGS := -X 'globstar.dev/pkg/cli.version=$$(git describe --tags 2>/dev/null || echo dev)'
+CLI_BUILD_FLAGS := -X 'globstar.dev/pkg/cli.version=$$(git describe --tags 2>/dev/null || echo dev)' \
+				   -X 'globstar.dev/pkg/cli.gitCommit=$$(git rev-parse --short HEAD)' \
+				   -X 'globstar.dev/pkg/cli.goVersion=$$(go version | awk '{print $$3}')' \
+				   -X 'globstar.dev/pkg/cli.goos=$$(go env GOOS)' \
+				   -X 'globstar.dev/pkg/cli.goarch=$$(go env GOARCH)'
 
 .PHONY: sysroot-pack
 sysroot-pack:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -16,6 +16,10 @@ builds:
       - amd64
     ldflags:
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
   # darwin-arm64
   - id: globstar-darwin-arm64
     main: ./cmd/globstar
@@ -30,6 +34,10 @@ builds:
       - arm64
     ldflags:
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
   # linux-amd64
   - id: globstar-linux-amd64
     main: ./cmd/globstar
@@ -44,6 +52,10 @@ builds:
       - amd64
     ldflags:
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
   # linux-arm64
   - id: globstar-linux-arm64
     main: ./cmd/globstar
@@ -58,6 +70,10 @@ builds:
       - arm64
     ldflags:
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
   # windows-amd64
   - id: globstar-windows-amd64
     main: ./cmd/globstar
@@ -73,6 +89,10 @@ builds:
     ldflags:
       - buildmode=exe
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
   # windows-arm64
   - id: globstar-windows-arm64
     main: ./cmd/globstar
@@ -88,6 +108,10 @@ builds:
     ldflags:
       - buildmode=exe
       - "-X 'globstar.dev/pkg/cli.version={{ .Version }}'"
+      - "-X 'globstar.dev/pkg/cli.gitCommit={{ .ShortCommit }}'"
+      - "-X 'globstar.dev/pkg/cli.goVersion={{ .Env.GOVERSION }}'"
+      - "-X 'globstar.dev/pkg/cli.goos={{ .Os }}'"
+      - "-X 'globstar.dev/pkg/cli.goarch={{ .Arch }}'"
 archives:
   - id: arch_rename
     builds:

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -52,7 +52,10 @@ func (c *Cli) Run() error {
 
 	cli.VersionPrinter = func(cmd *cli.Command) {
 		version := strings.TrimPrefix(cmd.Version, "v")
-		fmt.Println(version)
+		fmt.Printf("globstar %s %s/%s\n", version, goos, goarch)
+		fmt.Printf("commit %s\n", gitCommit)
+		fmt.Printf("built with %s\n", goVersion)
+		
 	}
 
 	cmd := &cli.Command{

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -2,4 +2,10 @@ package cli
 
 // current version of globstar
 // this will be overridden during the build process
-var version = "dev"
+var (
+	version   = "dev"
+	gitCommit = "unknown"
+	goVersion = "unknown"
+	goos      = "unknown"
+	goarch    = "unknown"
+)


### PR DESCRIPTION
Change description:

- add OS and build architecture information
- add git commit hash (short version)
- modify `goreleaser.yml` to incorporate version information to `ldflags`
- modify release github workflow to include go version in environment variable (to be used by `goreleaser`)

Output demo:

```console
❯ ./bin/globstar --version
globstar dev linux/amd64
commit 701ac83
built with go1.23.4
```

Related to #35 