### PR TITLE
feat(javascript): implement Go-based SQL injection checker

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -67,7 +67,7 @@ type Analyzer struct {
 var AnalyzerRegistry = []Analyzer{
 	{
 		TestDir:   "checkers/javascript/testdata", // relative to the repository root
-		Analyzers: []*goAnalysis.Analyzer{javascript.NoDoubleEq},
+		Analyzers: []*goAnalysis.Analyzer{javascript.NoDoubleEq, javascript.SQLInjection},
 	},
 }
 

--- a/checkers/javascript/sql_injection.go
+++ b/checkers/javascript/sql_injection.go
@@ -1,0 +1,133 @@
+package javascript
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var SQLInjection = &analysis.Analyzer{
+	Name:        "sql_injection",
+	Language:    analysis.LangJs,
+	Description: "Using raw SQL queries with unvalidated input can lead to SQL injection vulnerabilities",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityCritical,
+	Run:         detectSQLInjection,
+}
+
+func detectSQLInjection(pass *analysis.Pass) (interface{}, error) {
+	// Map of vulnerable function names to watch for
+	vulnerableFunctions := map[string]bool{
+		"query":             true,
+		"raw":               true,
+		"$queryRawUnsafe":   true,
+		"$executeRawUnsafe": true,
+	}
+
+	// Map to track variable definitions
+	varDefinitions := make(map[string]*sitter.Node)
+
+	// First pass: collect all variable definitions
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node == nil || node.Type() != "variable_declarator" {
+			return
+		}
+
+		nameNode := node.ChildByFieldName("name")
+		valueNode := node.ChildByFieldName("value")
+
+		// Ensure that the variable definition is valid
+		if nameNode != nil && nameNode.Type() == "identifier" && valueNode != nil {
+			varName := nameNode.Content(pass.FileContext.Source)
+			if varName != "" {
+				varDefinitions[varName] = valueNode
+			}
+		}
+	})
+
+	// Second pass: detect SQL injection vulnerabilities
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node == nil || node.Type() != "call_expression" {
+			return
+		}
+
+		funcNode := node.ChildByFieldName("function")
+		if funcNode == nil || funcNode.Type() != "member_expression" {
+			return
+		}
+
+		propertyNode := funcNode.ChildByFieldName("property")
+		if propertyNode == nil {
+			return
+		}
+
+		// Extract the function name
+		funcName := propertyNode.Content(pass.FileContext.Source)
+
+		// Check if this is a function that executes raw SQL
+		if !vulnerableFunctions[funcName] {
+			return
+		}
+
+		// Get the arguments of the function
+		args := node.ChildByFieldName("arguments")
+		if args == nil || args.NamedChildCount() == 0 {
+			return
+		}
+
+		// Get the first argument
+		firstArg := args.NamedChild(0)
+		if firstArg == nil {
+			return
+		}
+
+		// Check if the argument is vulnerable
+		if isSQLInjectionVulnerable(firstArg, pass.FileContext.Source, varDefinitions) {
+			pass.Report(pass, node, "Potential SQL injection vulnerability detected, use parameterized queries instead")
+		}
+	})
+
+	return nil, nil
+}
+
+func isSQLInjectionVulnerable(node *sitter.Node, sourceCode []byte, varDefs map[string]*sitter.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Type() {
+	case "binary_expression":
+		// Check for string concatenation
+		left := node.ChildByFieldName("left")
+		right := node.ChildByFieldName("right")
+
+		// If either side is an identifier, this could be user input
+		if (left != nil && left.Type() == "identifier") ||
+			(right != nil && right.Type() == "identifier") {
+			return true
+		}
+
+		// Recursively check both sides
+		return isSQLInjectionVulnerable(left, sourceCode, varDefs) ||
+			isSQLInjectionVulnerable(right, sourceCode, varDefs)
+
+	case "template_string":
+		// Check for template strings with interpolation
+		for i := range int(node.NamedChildCount()) {
+			child := node.NamedChild(i)
+			if child != nil && child.Type() == "template_substitution" {
+				return true
+			}
+		}
+
+	case "identifier":
+		// If it's a variable, check its definition
+		varName := node.Content(sourceCode)
+		if defNode, exists := varDefs[varName]; exists {
+			return isSQLInjectionVulnerable(defNode, sourceCode, varDefs)
+		} else { // If definition is not found, assume it to be vulnerable
+			return true
+		}
+	}
+
+	return false
+}

--- a/checkers/javascript/testdata/sql_injection.test.js
+++ b/checkers/javascript/testdata/sql_injection.test.js
@@ -1,0 +1,54 @@
+// VULNERABLE PATTERNS
+
+// Direct string concatenation/interpolation with user input
+const v1 = "SELECT * FROM users WHERE username = '" + username + "'";
+const v2 = `SELECT * FROM users WHERE email = '${email}' AND phone = ${phone}`;
+
+// <expect-error>
+connection.query(v1);
+
+// <expect-error>
+pool.query(v2);
+
+// Variable defined elsewhere
+// <expect-error>
+connection.query(v3);
+
+// ORMs with raw queries
+// <expect-error>
+sequelize.query(`SELECT * FROM products WHERE category = '${category}'`, {
+  type: sequelize.QueryTypes.SELECT,
+});
+
+// <expect-error>
+knex.raw(`SELECT * FROM users WHERE id = ${userId}`);
+
+// <expect-error>
+knex.raw(`SELECT * FROM users WHERE id = ${userId}` + `AND email = ${email}`);
+
+// <expect-error>
+const users = await prisma.$queryRawUnsafe(
+  `SELECT * FROM ${table} WHERE id = ${id}`,
+);
+
+// <expect-error>
+const result = await prisma.$executeRawUnsafe(
+  `DELETE FROM users WHERE email = '${email}'`,
+);
+
+// SAFE PATTERNS
+
+connection.query(s1, "SELECT * FROM user WHERE name LIKE 'A%'");
+
+// Parameterized queries
+const s1 = "SELECT * FROM users WHERE username = ?";
+connection.query(s1, [username]);
+
+const s2 = "SELECT * FROM users WHERE email = $1 AND phone = $2";
+pool.query(s2, [email, phone]);
+
+// Prepared statements
+const preparedStatement = connection.prepare(
+  "SELECT * FROM users WHERE id = ?",
+);
+preparedStatement.execute([userId]);


### PR DESCRIPTION
## Summary
This pull request introduces a Go-based static analysis checker designed to detect potential SQL injection vulnerabilities in JavaScript code. 

**Injection** is the **3rd most critical** web security risk in the [OWASP Top 10](https://owasp.org/Top10/A03_2021-Injection/). Among 94% of tested applications, it had a maximum incidence rate of 19% and an average of 3%. SQL injection remains a key pentesting target, making proper query sanitization essential to prevent unauthorized access and data loss.


## Detection Logic
The scanner works in two phases, during the first phase, it goes through and creates a map of all known variables in a file. This allows it to track where each variable is assigned a value, this is needed later on for detecting SQL injection vulnerabilities.

During the second phase, the scanner finds all function calls that are used to execute raw SQL queries. A variable named `vulnerableFunctions` is maintained for this purpose and it includes calls from [Supported ORM's](#supported-orms). After this, it follows the below flow:
1. It inspects the first argument of the SQL-executing function.
2. If the argument is a variable, it looks up its definition in the map created during the first phase.
3. If the argument (or variable) involves string concatenation (with a variable) or template literals with interpolation, it is flagged as vulnerable.
4. A recursive call is used to track chained concatenations (+) in order to detect indirect vulnerabilities.

## Supported ORMs
The checker currently covers **five widely used ORMs** in the JavaScript ecosystem:
1. **Sequelize** -> `.query()`
2. **TypeORM**  -> `.query()`
3. **Prisma** -> `$queryRawUnsafe()` and `$executeRawUnsafe()`
4. **Knex.js** -> `.raw()`
5. **Objection.js** -> `.raw()`
6. **node-postgres** -> `.query()` [Not an ORM but a popular interface nonetheless]

These ORMs are extensively used in projects, ensuring broad vulnerability detection.

## Note
I'm still new to Go and the initial version of the checker was written by Claude. However, I did personally go through and verify each line and make modifications to improve the overall flow and reduce redundancies. I believe the logic is sound, but please let me know if any changes are required.

I have also tested the checker using the new Go-based rules introduced in #123. Though i believe there is a bug with it (which is why the action fails)