### PR TITLE
chore: add checker to detect request.POST method after is_valid() check

### DIFF
--- a/checkers/python/post-after-isvalid.test.py
+++ b/checkers/python/post-after-isvalid.test.py
@@ -1,0 +1,48 @@
+from django.shortcuts import render, redirect
+from .models import *
+from .forms import *
+
+
+# The idea here is to create an model object called a Tournament, with a form for creation called CreateTournamentForm()
+# 
+# Django best practices are to use form.cleaned_data[] after validation to ensure you're accessing well-sanitized data:
+# https://docs.djangoproject.com/en/4.2/ref/forms/api/#accessing-clean-data
+# 
+# Some fairly typical django form object creation handlers
+# This handler does NOT use request.cleaned_data[], even after form.is_valid() has run
+def create_new_tournament_dangerous(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <expect-error>
+            t = Tournament(name=request.POST['name'])
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)
+    
+def create_new_tournament_dangerous(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <expect-error>
+            t = Tournament(name=request.POST.get('name'))
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)
+
+# This handler DOES use request.cleaned_data[], even after form.is_valid() has run
+def create_new_tournament_safe(request):
+    if request.method == 'POST':
+        form = CreateTournamentForm(request.POST)
+        if form.is_valid():
+# <no-error>
+            t = Tournament(name=form.cleaned_data['name'])
+            t.save()
+            return redirect('index')
+    else:
+        context = { 'form': CreateTournamentForm()}
+        return render(request, 'create_tournament.html', context)

--- a/checkers/python/post-after-isvalid.yml
+++ b/checkers/python/post-after-isvalid.yml
@@ -1,0 +1,36 @@
+language: py
+name: post-after-isvalid
+message: Detected request.POST after an is_valid() check
+category: security
+
+pattern: |
+  (subscript
+    value: (attribute
+      object: (identifier) @request
+      attribute: (identifier) @post)
+    subscript: (_)
+    (#eq? @request "request")
+    (#eq? @post "POST")) @post-after-isvalid
+
+  (call
+    function: (attribute
+      object: (attribute
+        object: (identifier) @request
+        attribute: (identifier) @post)
+      attribute: (identifier) @get)
+    (#eq? @request "request")
+    (#eq? @post "POST")
+    (#eq? @get "get")) @post-after-isvalid
+
+filters:
+  - pattern-inside: |
+      (if_statement
+        condition: (call
+          function: (attribute
+            object: (identifier)
+            attribute: (identifier) @isvalid)
+          arguments: (argument_list))
+        (#eq? @isvalid "is_valid"))
+
+description: |
+  Use form.cleaned_data[] instead of request.POST[]/request.POST.get() after form.is_valid() to access only sanitized data


### PR DESCRIPTION
Test logs:

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: post-after-isvalid.yml
Running test case: safe-string-extend.yml
All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.006s  coverage: 22.7% of statements
Total coverage: 13.9%
```