### PR TITLE
chore: add checker to detect usage of weak SSL version

### DIFF
--- a/checkers/python/ssl-wrap-socket-deprecated.test.py
+++ b/checkers/python/ssl-wrap-socket-deprecated.test.py
@@ -1,0 +1,22 @@
+import socket
+import ssl
+
+sock = socket.socket(
+    socket.AF_INET,
+    socket.SOCK_STREAM | socket.SOCK_NONBLOCK)
+
+# <expect-error>
+ssock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1)
+
+# <expect-error>
+ssock2 = ssl.wrap_socket(sock)
+
+context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+context.verify_mode = ssl.CERT_REQUIRED
+context.check_hostname = True
+context.load_default_certs()
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+# <no-error>
+ssl_sock = context.wrap_socket(s, server_hostname='www.verisign.com')
+ssl_sock.connect(('www.verisign.com', 443))

--- a/checkers/python/ssl-wrap-socket-deprecated.yml
+++ b/checkers/python/ssl-wrap-socket-deprecated.yml
@@ -1,0 +1,17 @@
+language: py
+name: ssl-wrap-socket-deprecated
+message: Do not use deprecated `ssl.wrap_socket()` which creates an insecure socket
+category: security
+
+pattern: >
+  (call
+    function: (attribute
+      object: (identifier) @ssl
+      attribute: (identifier) @wrapsocket)
+    arguments: (argument_list)
+    (#eq? @ssl "ssl")
+    (#eq? @wrapsocket "wrap_socket")) @ssl-wrap-socket-deprecated
+
+description: >
+  The `ssl.wrap_socket()` function is deprecated. It creates an insecure socket
+  without server name indication or hostname matching.


### PR DESCRIPTION
Test logs:

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: safe-string-extend.yml
Running test case: ssl-wrap-socket-deprecated.yml
All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.005s  coverage: 22.7% of statements
Total coverage: 13.9%
```