### PR TITLE
chore: add checker to detect usage of weak SSL version

### DIFF
--- a/checkers/python/weak-ssl-version.test.py
+++ b/checkers/python/weak-ssl-version.test.py
@@ -1,0 +1,57 @@
+# cf. https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/examples/ssl-insecure-version.py
+
+import ssl
+from pyOpenSSL import SSL
+
+# <expect-error>
+ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv2)
+# <expect-error>
+SSL.Context(method=SSL.SSLv2_METHOD)
+# <expect-error>
+SSL.Context(method=SSL.SSLv23_METHOD)
+
+# <no-error>
+ssl.wrap_socket(ssl_version=ssl.PROTOCOL_TLSv1_2)
+
+# <expect-error>
+some_other_method(ssl_version=ssl.PROTOCOL_SSLv2)
+# <expect-error>
+some_other_method(method=SSL.SSLv2_METHOD)
+# <expect-error>
+some_other_method(method=SSL.SSLv23_METHOD)
+
+# <expect-error>
+ssl.wrap_socket(ssl_version=ssl.PROTOCOL_SSLv3)
+# <expect-error>
+ssl.wrap_socket(ssl_version=ssl.PROTOCOL_TLSv1)
+# <expect-error>
+SSL.Context(method=SSL.SSLv3_METHOD)
+# <expect-error>
+SSL.Context(method=SSL.TLSv1_METHOD)
+
+# <expect-error>
+some_other_method(ssl_version=ssl.PROTOCOL_SSLv3)
+# <expect-error>
+some_other_method(ssl_version=ssl.PROTOCOL_TLSv1)
+# <expect-error>
+some_other_method(method=SSL.SSLv3_METHOD)
+# <expect-error>
+some_other_method(method=SSL.TLSv1_METHOD)
+
+ssl.wrap_socket()
+
+# <expect-error>
+def open_ssl_socket(version=ssl.PROTOCOL_SSLv2):
+    pass
+
+# <expect-error>
+def open_ssl_socket(version=SSL.SSLv2_METHOD):
+    pass
+
+# <expect-error>
+def open_ssl_socket(version=SSL.SSLv23_METHOD):
+    pass
+
+# <expect-error>
+def open_ssl_socket(version=SSL.TLSv1_1_METHOD):
+    pass

--- a/checkers/python/weak-ssl-version.yml
+++ b/checkers/python/weak-ssl-version.yml
@@ -1,6 +1,6 @@
 language: py
 name: weak-ssl-version
-message: An insecure version of SSL has been detected which is deprectated due to weak encryption
+message: Insecure SSL version detected which is deprecated due to weak encryption
 category: security
 
 patterns: 

--- a/checkers/python/weak-ssl-version.yml
+++ b/checkers/python/weak-ssl-version.yml
@@ -1,0 +1,21 @@
+language: py
+name: weak-ssl-version
+message: An insecure version of SSL has been detected which is deprectated due to weak encryption
+category: security
+
+patterns: 
+  - >
+    (attribute
+      object: (identifier) @ssl
+      attribute: (identifier) @version
+      (#eq? @ssl "ssl")
+      (#match? @version "^(PROTOCOL_SSLv2|PROTOCOL_SSLv3|PROTOCOL_TLSv1|PROTOCOL_TLSv1_1)$")) @weak-ssl-version
+  - >
+    (attribute
+      object: (identifier) @ssl
+      attribute: (identifier) @version
+      (#eq? @ssl "SSL")
+      (#match? @version "^(SSLv2_METHOD|SSLv23_METHOD|SSLv3_METHOD|TLSv1_METHOD|TLSv1_1_METHOD)$")) @weak-ssl-version
+
+description: >
+  An outdated and insecure SSL version was detected. TLS 1.0, TLS 1.1, and all SSL versions are considered weak encryption standards and have been deprecated due to known vulnerabilities. To ensure secure communication, it is recommended to use 'ssl.PROTOCOL_TLSv1_2' or a higher version, which provides stronger encryption and better protection against attacks.


### PR DESCRIPTION
Test logs

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: safe-string-extend.yml
Running test case: weak-ssl-version.yml
All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.005s  coverage: 22.7% of statements
Total coverage: 13.9%
```