### PR TITLE
chore: add checker to detect flask app running on insecure host

### DIFF
--- a/checkers/python/app-run-with-bad-host.test.py
+++ b/checkers/python/app-run-with-bad-host.test.py
@@ -1,0 +1,10 @@
+# Ref: https://owasp.org/Top10/A01_2021-Broken_Access_Control [OWASP A01:2021]
+
+#ruleid:avoid_app_run_with_bad_host
+app.run(host="0.0.0.0")
+
+#ruleid:avoid_app_run_with_bad_host
+app.run("0.0.0.0")
+
+# OK
+foo.run("0.0.0.0")

--- a/checkers/python/app-run-with-bad-host.test.py
+++ b/checkers/python/app-run-with-bad-host.test.py
@@ -1,9 +1,9 @@
 # Ref: https://owasp.org/Top10/A01_2021-Broken_Access_Control [OWASP A01:2021]
 
-#ruleid:avoid_app_run_with_bad_host
+# <expect-error>
 app.run(host="0.0.0.0")
 
-#ruleid:avoid_app_run_with_bad_host
+# <expect-error>
 app.run("0.0.0.0")
 
 # OK

--- a/checkers/python/app-run-with-bad-host.yml
+++ b/checkers/python/app-run-with-bad-host.yml
@@ -1,0 +1,31 @@
+language: py
+name: app-run-with-bad-host
+message: Running flask app with host `0.0.0.0` can expose the server publicly
+category: security
+severity: warning
+
+pattern: >
+  (call
+    function: (attribute
+      object: (identifier) @app
+      attribute: (identifier) @run)
+    arguments: (argument_list
+      (_)*
+      [
+      (keyword_argument
+        name: (identifier) @host
+        value: (string
+          (string_content) @ip))
+      
+      (string
+        (string_content) @ip)
+      ]
+      (_)*)
+    (#eq? @app "app")
+    (#eq? @run "run")
+    (#eq? @host "host")
+    (#eq? @ip "0.0.0.0")) @app-run-with-bad-host
+
+
+description: >
+  Running a Flask application with the host set to 0.0.0.0 allows it to accept connections from any network interface, potentially exposing the server to the public internet. This can pose security risks, as unauthorized users may be able to access the application if proper authentication and firewall rules are not in place

--- a/checkers/python/app-run-with-bad-host.yml
+++ b/checkers/python/app-run-with-bad-host.yml
@@ -1,6 +1,6 @@
 language: py
 name: app-run-with-bad-host
-message: Running flask app with host `0.0.0.0` can expose the server publicly
+message: Running Flask with host 0.0.0.0 allows connections from any network interface, posing a security risk.
 category: security
 severity: warning
 


### PR DESCRIPTION
Test logs:

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: app-run-with-bad-host.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: safe-string-extend.yml
All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.005s  coverage: 22.7% of statements
Total coverage: 13.9%
```