### PR TITLE
chore: add checker to detect flask secrets used as salt for HashIDs

### DIFF
--- a/checkers/python/hashids-with-flask-secret.test.py
+++ b/checkers/python/hashids-with-flask-secret.test.py
@@ -1,0 +1,20 @@
+from hashids import Hashids
+from flask import Flask
+
+from flask import current_app as app
+# <expect-error>
+hash_id = Hashids(salt=app.config['SECRET_KEY'], min_length=34)
+# <expect-error>
+hashids = Hashids(min_length=4, salt=app.config['SECRET_KEY'])
+
+from flask import current_app
+# <expect-error>
+hashids = Hashids(min_length=5, salt=current_app.config['SECRET_KEY'])
+
+foo = Flask(__name__)
+# <expect-error>
+hashids = Hashids(min_length=4, salt=foo.config['SECRET_KEY'])
+
+app = Flask(__name__.split('.')[0])
+# <expect-error>
+app._hashids = Hashids(salt=app.config['SECRET_KEY'])

--- a/checkers/python/hashids-with-flask-secret.yml
+++ b/checkers/python/hashids-with-flask-secret.yml
@@ -1,0 +1,28 @@
+language: py
+name: hashids-with-flask-secret
+message: Do not use Flask secret key as salt in HashIDs
+category: security
+
+pattern: >
+  (call
+    function: (identifier) @hashid
+    arguments: (argument_list
+      (_)*
+      (keyword_argument
+        name: (identifier) @salt
+        value: (subscript
+          value: (attribute
+            object: (identifier)
+            attribute: (identifier) @config)
+          subscript: (string
+            (string_content) @secretkey)))
+      (_)*)
+    (#eq? @hashid "Hashids")
+    (#eq? @salt "salt")
+    (#eq? @config "config")
+    (#eq? @secretkey "SECRET_KEY")) @hashids-with-flask-secret
+
+
+description: >
+  The Flask secret is vulnerable if its used as salt in HashID, because it is not
+  cryptographically secure. By collecting and analyzing a sufficient number of HashIDs, attackers can recover the salt value, effectively exposing the Flask secret key and potentially compromising the application's security.


### PR DESCRIPTION
Test logs:

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers/
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: hashids-with-flask-secret.yml
Running test case: safe-string-extend.yml
All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.005s  coverage: 22.7% of statements
Total coverage: 13.9%
```