### PR TITLE
feat: add support for `skipcq` comments to ignore issues

### DIFF
--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"regexp"
+	"slices"
 
 	sitter "github.com/smacker/go-tree-sitter"
 )
@@ -147,9 +147,9 @@ func RunAnalyzers(path string, analyzers []*Analyzer, fileFilter func(string) bo
 
 	reportFunc := func(pass *Pass, node *sitter.Node, message string) {
 		raisedIssue := &Issue{
-			Id: &pass.Analyzer.Name,
-			Node: node,
-			Message: message,
+			Id:       &pass.Analyzer.Name,
+			Node:     node,
+			Message:  message,
 			Filepath: pass.FileContext.FilePath,
 		}
 		if !ContainsSkipcq(pass, raisedIssue) {

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -155,12 +155,6 @@ func RunAnalyzers(path string, analyzers []*Analyzer, fileFilter func(string) bo
 		if !ContainsSkipcq(pass, raisedIssue) {
 			raisedIssues = append(raisedIssues, raisedIssue)
 		}
-		// raisedIssues = append(raisedIssues, &Issue{
-		// 	Id:       &pass.Analyzer.Name,
-		// 	Node:     node,
-		// 	Message:  message,
-		// 	Filepath: pass.FileContext.FilePath,
-		// })
 	}
 
 	for lang, analyzers := range langAnalyzerMap {

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -1,0 +1,111 @@
+package analysis
+
+import (
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseTestFile(t *testing.T, filename string, source string, language Language) *ParseResult {
+	parsed, err := Parse(filename, []byte(source), language, language.Grammar())
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	return parsed
+}
+
+// mock checker function for unit testing
+func mockChecker(pass *Pass) (interface{}, error) {
+	Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "assert_statement" {
+			pass.Report(pass, node, "Assert not allowed")
+		}
+	})
+
+	return nil, nil
+}
+
+
+func TestSkipCqComment(t *testing.T) {
+	tests := []struct {
+		name string
+		filename string
+		source string
+		language Language
+		checker func(*Pass) (any, error)
+		want bool
+	}{
+		{
+			name: "skipcq on same line",
+			filename: "no-assert.test.py",
+			source: `
+				def someFunc(a, b):
+					assert a == b # <skipcq>
+			`,
+			language: LangPy,
+			checker: mockChecker,
+			want: true,
+		},
+		{
+			name: "skipcq on previous line",
+			filename: "no-assert.test.py",
+			source: `
+				if True:
+					# <skipcq>
+					assert a == 10
+			`,
+			language: LangPy,
+			checker: mockChecker,
+			want: true,
+		},
+		{
+			name: "skipcq comment not present",
+			filename: "no-assert.test.py",
+			source: `
+				assert 1 == 2
+			`,
+			language: LangPy,
+			checker: mockChecker,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := parseTestFile(t, tt.filename, tt.source, tt.language)
+			analyzer := &Analyzer{
+				Name: "no-assert",
+				Description: "analyzer for testing",
+				Category: CategorySecurity,
+				Severity: SeverityWarning,
+				Language: tt.language,
+				Requires: []*Analyzer{},
+				Run: tt.checker,
+			}
+
+			var reportNode *sitter.Node
+
+			pass := &Pass{
+				Analyzer: analyzer,
+				FileContext: parsed,
+				Files: []*ParseResult{parsed},
+				Report: func(p *Pass, n *sitter.Node, msg string) {
+					reportNode = n
+				},
+			}
+
+			_, err := mockChecker(pass)
+			require.NoError(t, err)
+			require.NotNil(t, reportNode, "checker should return a non-nil node for assert")
+
+			issue := &Issue{
+				Filepath: "no-assert.test.py",
+				Node: reportNode,
+			}
+			
+			result := ContainsSkipcq(pass, issue)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -26,29 +26,28 @@ func mockChecker(pass *Pass) (interface{}, error) {
 	return nil, nil
 }
 
-
 func TestSkipCqComment(t *testing.T) {
 	tests := []struct {
-		name string
+		name     string
 		filename string
-		source string
+		source   string
 		language Language
-		checker func(*Pass) (any, error)
-		want bool
+		checker  func(*Pass) (any, error)
+		want     bool
 	}{
 		{
-			name: "skipcq on same line",
+			name:     "skipcq on same line",
 			filename: "no-assert.test.py",
 			source: `
 				def someFunc(a, b):
 					assert a == b # <skipcq>
 			`,
 			language: LangPy,
-			checker: mockChecker,
-			want: true,
+			checker:  mockChecker,
+			want:     true,
 		},
 		{
-			name: "skipcq on previous line",
+			name:     "skipcq on previous line",
 			filename: "no-assert.test.py",
 			source: `
 				if True:
@@ -56,18 +55,18 @@ func TestSkipCqComment(t *testing.T) {
 					assert a == 10
 			`,
 			language: LangPy,
-			checker: mockChecker,
-			want: true,
+			checker:  mockChecker,
+			want:     true,
 		},
 		{
-			name: "skipcq comment not present",
+			name:     "skipcq comment not present",
 			filename: "no-assert.test.py",
 			source: `
 				assert 1 == 2
 			`,
 			language: LangPy,
-			checker: mockChecker,
-			want: false,
+			checker:  mockChecker,
+			want:     false,
 		},
 	}
 
@@ -75,21 +74,21 @@ func TestSkipCqComment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parsed := parseTestFile(t, tt.filename, tt.source, tt.language)
 			analyzer := &Analyzer{
-				Name: "no-assert",
+				Name:        "no-assert",
 				Description: "analyzer for testing",
-				Category: CategorySecurity,
-				Severity: SeverityWarning,
-				Language: tt.language,
-				Requires: []*Analyzer{},
-				Run: tt.checker,
+				Category:    CategorySecurity,
+				Severity:    SeverityWarning,
+				Language:    tt.language,
+				Requires:    []*Analyzer{},
+				Run:         tt.checker,
 			}
 
 			var reportNode *sitter.Node
 
 			pass := &Pass{
-				Analyzer: analyzer,
+				Analyzer:    analyzer,
 				FileContext: parsed,
-				Files: []*ParseResult{parsed},
+				Files:       []*ParseResult{parsed},
 				Report: func(p *Pass, n *sitter.Node, msg string) {
 					reportNode = n
 				},
@@ -101,9 +100,9 @@ func TestSkipCqComment(t *testing.T) {
 
 			issue := &Issue{
 				Filepath: "no-assert.test.py",
-				Node: reportNode,
+				Node:     reportNode,
 			}
-			
+
 			result := ContainsSkipcq(pass, issue)
 			assert.Equal(t, tt.want, result)
 		})

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -263,7 +263,6 @@ func (ana *Analyzer) runParentFilters(checker YamlChecker, node *sitter.Node) bo
 	return true
 }
 
-
 func (ana *Analyzer) executeCheckerQuery(checker YamlChecker, query *sitter.Query) {
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()

--- a/pkg/analysis/analyze_test.go
+++ b/pkg/analysis/analyze_test.go
@@ -1,0 +1,91 @@
+package analysis
+
+import (
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseTestFile(t *testing.T, filename string, source string, language Language) *ParseResult {
+	parsed, err := Parse(filename, []byte(source), language, language.Grammar())
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	return parsed
+}
+
+func TestSkipCq(t *testing.T) {
+	tests := []struct{
+		name string
+		source string
+		language Language
+		want bool
+	}{
+		{
+			name: "skipcq comment on same line",
+			language: LangPy,
+			source: `
+				def someFunc(a, b):
+					assert a == b # <skipcq>
+			`,
+			want: true,
+		},
+		{
+			name: "skipcq comment on previous line",
+			language: LangPy,
+			source: `
+				if True:
+				# <skipcq>
+					assert 1 == 2
+			`,
+			want: true,
+		},
+		{
+			name: "skipcq comment not present",
+			language: LangPy,
+			source: `
+				assert a == b
+			`,
+			want: false,
+		},
+
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := parseTestFile(t, "no-assert.test.py", tt.source, tt.language)
+			analyzer := &Analyzer{
+				Language: tt.language,
+				ParseResult: parsed,
+			}
+
+			query, err := sitter.NewQuery([]byte("(assert_statement) @assert"), tt.language.Grammar())
+			require.NoError(t, err)
+
+			cursor := sitter.NewQueryCursor()
+			cursor.Exec(query, parsed.Ast)
+
+			match, ok := cursor.NextMatch()
+			require.True(t, ok, "failed to find assert statements")
+
+			var assertNode *sitter.Node
+			for _, captureNode := range match.Captures {
+				if query.CaptureNameForId(captureNode.Index) == "assert" {
+					assertNode = captureNode.Node
+					break
+				}
+			}
+
+			require.NotNil(t, assertNode, "failed to capture assert node")
+
+			issue := &Issue{
+				Filepath: "no-assert.test.py",
+				Node: assertNode,
+			}
+
+			res := analyzer.ContainsSkipcq(issue)
+			assert.Equal(t, tt.want, res)
+		})
+	}
+}

--- a/pkg/analysis/analyze_test.go
+++ b/pkg/analysis/analyze_test.go
@@ -16,14 +16,14 @@ func parseTestFile(t *testing.T, filename string, source string, language Langua
 }
 
 func TestSkipCq(t *testing.T) {
-	tests := []struct{
-		name string
-		source string
+	tests := []struct {
+		name     string
+		source   string
 		language Language
-		want bool
+		want     bool
 	}{
 		{
-			name: "skipcq comment on same line",
+			name:     "skipcq comment on same line",
 			language: LangPy,
 			source: `
 				def someFunc(a, b):
@@ -32,7 +32,7 @@ func TestSkipCq(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "skipcq comment on previous line",
+			name:     "skipcq comment on previous line",
 			language: LangPy,
 			source: `
 				if True:
@@ -42,21 +42,20 @@ func TestSkipCq(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "skipcq comment not present",
+			name:     "skipcq comment not present",
 			language: LangPy,
 			source: `
 				assert a == b
 			`,
 			want: false,
 		},
-
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parsed := parseTestFile(t, "no-assert.test.py", tt.source, tt.language)
 			analyzer := &Analyzer{
-				Language: tt.language,
+				Language:    tt.language,
 				ParseResult: parsed,
 			}
 
@@ -81,7 +80,7 @@ func TestSkipCq(t *testing.T) {
 
 			issue := &Issue{
 				Filepath: "no-assert.test.py",
-				Node: assertNode,
+				Node:     assertNode,
 			}
 
 			res := analyzer.ContainsSkipcq(issue)

--- a/pkg/analysis/language.go
+++ b/pkg/analysis/language.go
@@ -296,3 +296,21 @@ func ParseFile(filePath string) (*ParseResult, error) {
 
 	return Parse(filePath, source, lang, grammar)
 }
+
+func GetEscapedCommentIdentifierFromPath(path string) string {
+	lang := LanguageFromFilePath(path)
+	switch lang {
+	case LangJs, LangTs, LangTsx, LangJava, LangRust, LangCss, LangMarkdown, LangKotlin, LangCsharp, LangGo, LangGroovy, LangPhp, LangScala, LangSwift:
+		return "\\/\\/"
+	case LangPy, LangLua, LangBash, LangRuby, LangYaml, LangDockerfile, LangElixir, LangHcl:
+		return "#"
+	case LangSql, LangElm:
+		return "--"
+	case LangHtml:
+		return "<\\!--"
+	case LangOCaml:
+		return "\\(\\*"
+	default:
+		return ""
+	}
+}

--- a/pkg/analysis/pattern_rule.go
+++ b/pkg/analysis/pattern_rule.go
@@ -106,7 +106,10 @@ func (r *patternCheckerImpl) OnMatch(
 		Severity: r.Severity(),
 		Id: &r.issueId,
 	}
-	if !ana.ContainsSkipcq(raisedIssue) {
+
+	filepath := ana.ParseResult.FilePath
+	skipComments := fileSkipComment[filepath]
+	if !ana.ContainsSkipcq(skipComments, raisedIssue) {
 		ana.Report(raisedIssue)
 	}
 }

--- a/pkg/analysis/pattern_rule.go
+++ b/pkg/analysis/pattern_rule.go
@@ -109,16 +109,6 @@ func (r *patternCheckerImpl) OnMatch(
 	if !ana.ContainsSkipcq(raisedIssue) {
 		ana.Report(raisedIssue)
 	}
-
-	// ana.Report(&Issue{
-	// 	Range:    matchedNode.Range(),
-	// 	Node:     matchedNode,
-	// 	Message:  message,
-	// 	Filepath: ana.ParseResult.FilePath,
-	// 	Category: r.Category(),
-	// 	Severity: r.Severity(),
-	// 	Id:       &r.issueId,
-	// })
 }
 
 func (r *patternCheckerImpl) Name() string {

--- a/pkg/analysis/pattern_rule.go
+++ b/pkg/analysis/pattern_rule.go
@@ -97,16 +97,28 @@ func (r *patternCheckerImpl) OnMatch(
 			)
 		}
 	}
-
-	ana.Report(&Issue{
-		Range:    matchedNode.Range(),
-		Node:     matchedNode,
-		Message:  message,
+	raisedIssue := &Issue{
+		Range: matchedNode.Range(),
+		Node: matchedNode,
+		Message: message,
 		Filepath: ana.ParseResult.FilePath,
 		Category: r.Category(),
 		Severity: r.Severity(),
-		Id:       &r.issueId,
-	})
+		Id: &r.issueId,
+	}
+	if !ana.ContainsSkipcq(raisedIssue) {
+		ana.Report(raisedIssue)
+	}
+
+	// ana.Report(&Issue{
+	// 	Range:    matchedNode.Range(),
+	// 	Node:     matchedNode,
+	// 	Message:  message,
+	// 	Filepath: ana.ParseResult.FilePath,
+	// 	Category: r.Category(),
+	// 	Severity: r.Severity(),
+	// 	Id:       &r.issueId,
+	// })
 }
 
 func (r *patternCheckerImpl) Name() string {


### PR DESCRIPTION
This PR introduces support for `skipcq` comments to ignore specific issues in the source code.

### Checklist

- [X] Implement support for basic `skipcq` functionality (ignores all checkers)
- [X] Implements support for targeted `skipcq` functionality to ignore specific checkers by their ID
- [X] Add unit tests

Fixes #135 
