### PR TITLE
checker(python): dangerous subprocess exec in aws-lambda handler functions

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -58,6 +58,11 @@ func LoadCustomYamlCheckers(dir string) (map[analysis.Language][]analysis.YamlCh
 	return checkersMap, err
 }
 
+type Analyzer struct {
+	TestDir   string
+	Analyzers []*goAnalysis.Analyzer
+}
+
 func LoadGoCheckers() []*goAnalysis.Analyzer {
 	analyzers := []*goAnalysis.Analyzer{}
 
@@ -65,11 +70,6 @@ func LoadGoCheckers() []*goAnalysis.Analyzer {
 		analyzers = append(analyzers, analyzer.Analyzers...)
 	}
 	return analyzers
-}
-
-type Analyzer struct {
-	TestDir   string
-	Analyzers []*goAnalysis.Analyzer
 }
 
 func RunAnalyzerTests(analyzerRegistry []Analyzer) (bool, []error) {

--- a/checkers/python/dangerous-create-exec.go
+++ b/checkers/python/dangerous-create-exec.go
@@ -1,0 +1,207 @@
+package python
+
+import (
+	"regexp"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var DangerousCreateExec *analysis.Analyzer = &analysis.Analyzer{
+	Name:        "dangerous-create-exec",
+	Language:    analysis.LangPy,
+	Description: "This checker detects when `create_subprocess_exec` has tainted data passed into it. This can cause a Command Injection vulnerability",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityError,
+	Run:         dangerousCreateExec,
+}
+
+func dangerousCreateExec(pass *analysis.Pass) (interface{}, error) {
+	eventVars := make(map[string]bool)
+
+	// first pass to get variables tainted by event
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		// check if this is an assignment
+		if node.Type() != "assignment" {
+			return
+		}
+
+		left := node.ChildByFieldName("left")
+		right := node.ChildByFieldName("right")
+
+		if left.Type() == "identifier" && isEventSource(right, pass.FileContext.Source) {
+			eventVars[left.Content(pass.FileContext.Source)] = true
+		}
+
+	})
+
+	// second pass to find where the unsafe variables have been used
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil && argNode.NamedChildCount() >= 2 {
+				listSplat := argNode.NamedChild(1)
+
+				if listSplat != nil && listSplat.NamedChildCount() > 0 {
+					listSplatName := listSplat.NamedChild(0)
+
+					if listSplatName.Type() == "identifier" {
+						listSplatNameContent := listSplatName.Content(pass.FileContext.Source)
+
+						if eventVars[listSplatNameContent] {
+							pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")
+						}
+					}
+				}
+			}
+		}
+	})
+
+	// find where tainted event parameter has been directly used
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil && argNode.NamedChildCount() >= 2 {
+				eventvarNode := argNode.NamedChild(1)
+				
+				if eventvarNode.Type() != "subscript" {
+					return
+				}
+
+				eventVarSubscript := eventvarNode.ChildByFieldName("value")
+
+				if eventVarSubscript.Content(pass.FileContext.Source) == "event" {
+					pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")
+				}
+			}
+		}
+	})
+
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil && argNode.NamedChildCount() >= 4 {
+				shellNode := argNode.NamedChild(1)
+				eventNode := argNode.NamedChild(3)
+
+				if shellNode.Type() != "string" || eventNode.Type() != "identifier" {
+					return
+				}
+
+				shellString := shellNode.Content(pass.FileContext.Source)
+				eventVar := eventNode.Content(pass.FileContext.Source)
+
+				if isShell(shellString) && eventVars[eventVar] {
+					pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")
+				}
+			}
+		}
+	})
+
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil  && argNode.NamedChildCount() >= 4 {
+				shellNode := argNode.NamedChild(1)
+				eventNode := argNode.NamedChild(3)
+
+				if shellNode.Type() != "string" || eventNode.Type() != "subscript" {
+					return
+				}
+
+				shellString := shellNode.Content(pass.FileContext.Source)
+				eventVarSubscript := eventNode.ChildByFieldName("value")
+
+				if isShell(shellString) && eventVarSubscript.Content(pass.FileContext.Source) == "event" {
+					pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")
+				}
+			}
+		}
+	})
+
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil && argNode.NamedChildCount() >= 2 {
+				listNode := argNode.NamedChild(1)
+
+				if listNode.Type() != "list" {
+					return
+				}
+
+				shellNode := listNode.NamedChild(0)
+				eventNode := listNode.NamedChild(2)
+
+				if shellNode.Type() != "string" || eventNode.Type() != "identifier" {
+					return
+				}
+
+				shellString := shellNode.Content(pass.FileContext.Source)
+				eventVar := eventNode.Content(pass.FileContext.Source)
+
+				if isShell(shellString) && eventVars[eventVar] {
+					pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")
+				}
+			}
+		}
+	})
+
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "call" && isFunctionNamed(node, pass.FileContext.Source) {
+			argNode := node.ChildByFieldName("arguments")
+
+			if argNode != nil && argNode.NamedChildCount() >= 2 {
+				listNode := argNode.NamedChild(1)
+
+				if listNode.Type() != "list" {
+					return
+				}
+				
+				shellNode := listNode.NamedChild(0)
+				eventNode := listNode.NamedChild(2)
+
+				if shellNode.Type() != "string" || eventNode.Type() != "subscript" {
+					return
+				}
+
+				shellString := shellNode.Content(pass.FileContext.Source)
+				eventVarSubscript := eventNode.ChildByFieldName("value")
+
+				if isShell(shellString) && eventVarSubscript.Content(pass.FileContext.Source) == "event" {
+					pass.Report(pass, node, "Detected passing tainted data from `event` parameter directly to an exec method which can cause command injection vulnerabilities")	
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func isEventSource(node *sitter.Node, source []byte) bool {
+	if node.Type() == "subscript" && node.ChildByFieldName("value").Content(source) == "event" {
+		return true
+	}
+	return false
+}
+
+func isFunctionNamed(node *sitter.Node, source []byte) bool {
+	funcName := node.ChildByFieldName("function").Content(source)
+
+	if funcName == "asyncio.subprocess.create_subprocess_exec" || funcName == "subprocess.create_subprocess_exec" || funcName == "create_subprocess_exec" {
+
+		return true
+	}
+	return false
+}
+
+func isShell(shellString string) bool {
+	shellString = strings.Trim(shellString, `"'`)
+	shellPattern := regexp.MustCompile(`(^|/)?(sh|bash|ksh|csh|tcsh|zsh)$`)
+	return shellPattern.MatchString(shellString)
+}

--- a/checkers/python/testdata/dangerous-create-exec.test.py
+++ b/checkers/python/testdata/dangerous-create-exec.test.py
@@ -1,0 +1,53 @@
+import asyncio
+
+class AsyncEventLoop:
+    def __enter__(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        return self.loop
+
+    def __exit__(self, *args):
+        self.loop.close()
+
+
+def handler_func1(event, context):
+    args = event['cmds']
+    program = args[0]
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, *args))
+        loop.run_until_complete(proc.communicate())
+
+def handler_func2(event, context):
+    program = "bash"
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, event['cmd']))
+        loop.run_until_complete(proc.communicate())
+
+
+def handler_func3(event, context):
+    program = "sh"
+    eventcmd = event['cmd']
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, "bash", "-c", eventcmd))
+
+def handler_func4(event, context):
+    program = "sh"
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, "bash", "-c", event['cmd']))
+
+def handler_func5(event, context):
+    program = "sh"
+    args = event['cmds']
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, ["bash", "-c", args]))
+
+def handler_func5(event, context):
+    program = "sh"
+    with AsyncEventLoop() as loop:
+        # <expect-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, ["bash", "-c", event['cmds']]))

--- a/checkers/python/testdata/dangerous-create-exec.test.py
+++ b/checkers/python/testdata/dangerous-create-exec.test.py
@@ -46,7 +46,7 @@ def handler_func5(event, context):
         # <expect-error>
         proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, ["bash", "-c", args]))
 
-def handler_func5(event, context):
+def handler_func6(event, context):
     program = "sh"
     with AsyncEventLoop() as loop:
         # <expect-error>

--- a/checkers/python/testdata/dangerous-create-exec.test.py
+++ b/checkers/python/testdata/dangerous-create-exec.test.py
@@ -51,3 +51,24 @@ def handler_func6(event, context):
     with AsyncEventLoop() as loop:
         # <expect-error>
         proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, ["bash", "-c", event['cmds']]))
+
+def ok_handler1(event, context):
+    program = "echo"
+    loop = asyncio.new_event_loop()
+    # <no-error>
+    proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, [program, "123"]))
+    loop.run_until_complete(proc.communicate())
+
+def ok_handler2(event, context):
+    program = "sudo"
+    ok_cmd2 = "cat"
+    with AsyncEventLoop() as loop:
+        # <no-error>
+        proc = loop.run_until_complete(asyncio.subprocess.create_subprocess_exec(program, "bash", "-c", ok_cmd2))
+
+def ok_handler3(event, context):
+    program = "sudo"
+    ok_cmd3 = "rm -rf /"
+    with AsyncEventLoop() as loop:
+        # <no-error>
+        proc = loop.run_until_complete(subprocess.create_subprocess_exec(program, ok_cmd3))


### PR DESCRIPTION
Test logs

```
Testing built-in rules...
./bin/globstar test -d checkers
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: hashid-with-django-secret.yml
Running test case: safe-string-extend.yml
Running test case: weak-ssl-version.yml
Running tests in checkers/javascript/testdata for analyzers:
  Running tests for analyzer no-double-eq

Running tests in checkers/python/testdata for analyzers:
  Running tests for analyzer dangerous-create-exec

All tests passed        globstar.dev/cmd/globstar               coverage: 0.0% of statements
        globstar.dev/pkg/cli            coverage: 0.0% of statements
        globstar.dev/pkg/config         coverage: 0.0% of statements
ok      globstar.dev/pkg/analysis       0.005s  coverage: 22.5% of statements
Total coverage: 12.8%
```