### PR TITLE
checker(python): add checkers to detect insecure ftp connections in `urllib`

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -72,7 +72,7 @@ var AnalyzerRegistry = []Analyzer{
 	},
 	{
 		TestDir: "checkers/python/testdata",
-		Analyzers: []*goAnalysis.Analyzer{python.InsecureOpenerDirectorFtpOpen},
+		Analyzers: []*goAnalysis.Analyzer{python.InsecureUrllibFtp},
 	},
 }
 

--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -9,6 +9,7 @@ import (
 
 	goAnalysis "globstar.dev/analysis"
 	"globstar.dev/checkers/javascript"
+	"globstar.dev/checkers/python"
 	"globstar.dev/pkg/analysis"
 )
 
@@ -68,6 +69,10 @@ var AnalyzerRegistry = []Analyzer{
 	{
 		TestDir:   "checkers/javascript/testdata", // relative to the repository root
 		Analyzers: []*goAnalysis.Analyzer{javascript.NoDoubleEq, javascript.SQLInjection},
+	},
+	{
+		TestDir: "checkers/python/testdata",
+		Analyzers: []*goAnalysis.Analyzer{python.InsecureOpenerDirectorFtpOpen},
 	},
 }
 

--- a/checkers/python/insecure-urllib-ftp.go
+++ b/checkers/python/insecure-urllib-ftp.go
@@ -1,0 +1,155 @@
+package python
+
+import (
+	"regexp"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var InsecureOpenerDirectorFtpOpen *analysis.Analyzer = &analysis.Analyzer{
+	Name:        "insecure-urllib-ftp",
+	Language:    analysis.LangPy,
+	Description: "An unsecured FTP connection was detected where ftp:// is being used. Data transmitted over this channel is unencrypted, posing a security risk. It is recommended to use SFTP instead. Since urllib does not support SFTP, consider using a library that provides secure file transfer capabilities.",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityError,
+	Run:         checkInsecureOpenerDirectorFtpOpen,
+}
+
+func checkInsecureOpenerDirectorFtpOpen(pass *analysis.Pass) (interface{}, error) {
+	urlVarMap := make(map[string]bool)
+	odVarMap := make(map[string]bool)
+
+	// check if url exists as function parameters
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "function_definition" {
+			return
+		}
+
+		// check default parameter variable
+		funcParams := node.ChildByFieldName("parameters")
+		if funcParams.Type() != "parameters" {
+			return
+		}
+
+		if funcParams.NamedChildCount() > 0 {
+			parameterNodes := getNamedChildren(funcParams, 0)
+
+			for _, paramNode := range parameterNodes {
+				ok, name := isInsecureUrl(paramNode, pass.FileContext.Source)
+				if ok {
+					urlVarMap[name] = true
+				}
+			}
+		}
+	})
+
+	// check for insecure assignments
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() == "assignment" {
+			leftNode := node.ChildByFieldName("left")
+			rightNode := node.ChildByFieldName("right")
+
+			varContent := rightNode.Content(pass.FileContext.Source)
+
+			// check if ftp url is stored in a variable
+			if isFtpUrl(trimQuotes(varContent)) {
+				urlVarMap[leftNode.Content(pass.FileContext.Source)] = true
+			}
+
+			// check if OpenerDirector instance is created
+			if strings.Contains(varContent, "OpenerDirector") || strings.Contains(varContent, "Request") || strings.Contains(varContent, "URLopener") {
+				odVarMap[leftNode.Content(pass.FileContext.Source)] = true
+			}
+		}
+	})
+
+	// direct passing of ftp urls
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "call" {
+			return
+		}
+
+		functionNode := node.ChildByFieldName("function")
+
+		if !isOpenDirectorCall(functionNode, pass.FileContext.Source, odVarMap) {
+			return
+		}
+
+		argNodes := node.ChildByFieldName("arguments")
+		if argNodes != nil && argNodes.NamedChildCount() > 0 {
+			urlNode := argNodes.NamedChild(0)
+
+			if urlNode.Type() == "string" {
+				urlString := trimQuotes(urlNode.Content(pass.FileContext.Source))
+				if isFtpUrl(urlString) {
+					pass.Report(pass, node, "Unsecured FTP connection detected. Data is unencrypted—use SFTP instead.")
+				}
+			} else if urlNode.Type() == "identifier" {
+				urlVarName := urlNode.Content(pass.FileContext.Source)
+				if urlVarMap[urlVarName] {
+					pass.Report(pass, node, "Unsecured FTP connection detected. Data is unencrypted—use SFTP instead.")
+				}
+			}
+
+		}
+	})
+
+	return nil, nil
+}
+
+func isOpenDirectorCall(node *sitter.Node, source []byte, odVarMap map[string]bool) bool {
+	funcContent := node.Content(source)
+	if strings.Contains(funcContent, "OpenerDirector") || strings.Contains(funcContent, "Request") || strings.Contains(funcContent, "urlopen") || strings.Contains(funcContent, "URLopener") || strings.Contains(funcContent, "urlretrieve") {
+		return true
+	}
+
+	for odVar := range odVarMap {
+		if strings.Contains(funcContent, odVar) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// get all the children nodes of a node
+func getNamedChildren(node *sitter.Node, startIdx int) []*sitter.Node {
+	var namedChildren []*sitter.Node
+	childrenCount := node.NamedChildCount()
+
+	for i := startIdx; i < int(childrenCount); i++ {
+		namedChildren = append(namedChildren, node.NamedChild(i))
+	}
+
+	return namedChildren
+}
+
+// check if url is an insecure fpt link
+func isInsecureUrl(node *sitter.Node, source []byte) (bool, string) {
+	if node.Type() == "default_parameter" {
+		paramNameNode := node.ChildByFieldName("name")
+		paramValueNode := node.ChildByFieldName("value")
+
+		paramName := paramNameNode.Content(source)
+		urlString := trimQuotes(paramValueNode.Content(source))
+
+		if isFtpUrl(urlString) {
+			return true, paramName
+		}
+		return false, ""
+
+	}
+
+	return false, ""
+}
+
+func isFtpUrl(s string) bool {
+	pattern := `(?i)^ftp://.*`
+	return regexp.MustCompile(pattern).MatchString(s)
+}
+
+func trimQuotes(s string) string {
+	return strings.Trim(s, "\"")
+}

--- a/checkers/python/insecure-urllib-ftp.go
+++ b/checkers/python/insecure-urllib-ftp.go
@@ -8,16 +8,16 @@ import (
 	"globstar.dev/analysis"
 )
 
-var InsecureOpenerDirectorFtpOpen *analysis.Analyzer = &analysis.Analyzer{
+var InsecureUrllibFtp *analysis.Analyzer = &analysis.Analyzer{
 	Name:        "insecure-urllib-ftp",
 	Language:    analysis.LangPy,
-	Description: "An unsecured FTP connection was detected where ftp:// is being used. Data transmitted over this channel is unencrypted, posing a security risk. It is recommended to use SFTP instead. Since urllib does not support SFTP, consider using a library that provides secure file transfer capabilities.",
+	Description: "An unsecured FTP connection was detected where `ftp://` is being used. Data transmitted over this channel is unencrypted, posing a security risk. It is recommended to use `SFTP` instead. Since `urllib` does not support `SFTP`, consider using a library that provides secure file transfer capabilities.",
 	Category:    analysis.CategorySecurity,
 	Severity:    analysis.SeverityError,
-	Run:         checkInsecureOpenerDirectorFtpOpen,
+	Run:         checkInsecureUrllibFtp,
 }
 
-func checkInsecureOpenerDirectorFtpOpen(pass *analysis.Pass) (interface{}, error) {
+func checkInsecureUrllibFtp(pass *analysis.Pass) (interface{}, error) {
 	urlVarMap := make(map[string]bool)
 	odVarMap := make(map[string]bool)
 
@@ -73,7 +73,7 @@ func checkInsecureOpenerDirectorFtpOpen(pass *analysis.Pass) (interface{}, error
 
 		functionNode := node.ChildByFieldName("function")
 
-		if !isOpenDirectorCall(functionNode, pass.FileContext.Source, odVarMap) {
+		if !isUrllibCall(functionNode, pass.FileContext.Source, odVarMap) {
 			return
 		}
 
@@ -99,7 +99,7 @@ func checkInsecureOpenerDirectorFtpOpen(pass *analysis.Pass) (interface{}, error
 	return nil, nil
 }
 
-func isOpenDirectorCall(node *sitter.Node, source []byte, odVarMap map[string]bool) bool {
+func isUrllibCall(node *sitter.Node, source []byte, odVarMap map[string]bool) bool {
 	funcContent := node.Content(source)
 	if strings.Contains(funcContent, "OpenerDirector") || strings.Contains(funcContent, "Request") || strings.Contains(funcContent, "urlopen") || strings.Contains(funcContent, "URLopener") || strings.Contains(funcContent, "urlretrieve") {
 		return true

--- a/checkers/python/testdata/insecure-urllib-ftp.test.py
+++ b/checkers/python/testdata/insecure-urllib-ftp.test.py
@@ -1,0 +1,262 @@
+from urllib.request import OpenerDirector
+from urllib.request import Request
+from urllib.request import urlopen
+from urllib.request import URLopener
+from urllib.request import urlretrieve
+
+
+
+def test1():
+    od = OpenerDirector()
+    # <expect-error>
+    od.open("ftp://example.com")
+
+def test1_ok():
+    od = OpenerDirector()
+    # <no-error>
+    od.open("sftp://example.com")
+
+def test2():
+    od = OpenerDirector()
+    url2 = "ftp://example.com"
+    # <expect-error>
+    od.open(url2)
+
+def test2_ok():
+    od = OpenerDirector()
+    # <no-error>
+    url2_ok = "sftp://example.com"
+    od.open(url2_ok)
+
+def test3():
+    # <expect-error>
+    OpenerDirector().open("ftp://example.com")
+
+def test3_ok():
+    # <no-error>
+    OpenerDirector().open("sftp://example.com")
+
+def test4():
+    url4 = "ftp://example.com"
+    # <expect-error>
+    OpenerDirector().open(url4)
+
+def test4_ok():
+    # <no-error>
+    url4_ok = "sftp://example.com"
+    OpenerDirector().open(url4_ok)
+
+def test5(url5 = "ftp://example.com"):
+    # <expect-error>
+    OpenerDirector().open(url5)
+
+def test5_ok(url5_ok = "sftp://example.com"):
+    # <no-error>
+    OpenerDirector().open(url5_ok)
+
+def test6(url6 = "ftp://example.com"):
+    od = OpenerDirector()
+    # <expect-error>
+    od.open(url6)
+
+def test6_ok(url6_ok = "sftp://example.com"):
+    od = OpenerDirector()
+    # <no-error>
+    od.open(url6_ok)
+
+
+def test7():
+    # <expect-error>
+    Request("ftp://example.com")
+
+def test7_ok():
+    # <no-error>
+    Request("sftp://example.com")
+
+def test8():
+    url8 = "ftp://example.com"
+    # <expect-error>
+    Request(url8)
+
+def test8_ok():
+    # <no-error>
+    url8_ok = "sftp://example.com"
+    Request(url8_ok)
+
+def test9(url9 = "ftp://example.com"):
+    # <expect-error>
+    Request(url9)
+
+def test9_ok(url9_ok = "sftp://example.com"):
+    # <no-error>
+    Request(url9_ok)
+
+def test10():
+    # <expect-error>
+    urlopen("ftp://example.com")
+
+def test10_ok():
+    # <no-error>
+    urlopen("sftp://example.com")
+
+def test11():
+    url11 = "ftp://example.com"
+    # <expect-error>
+    urlopen(url11)
+
+def test11_ok():
+    url11_ok = "sftp://example.com"
+    # <no-error>
+    urlopen(url11_ok)
+
+def test12(url12 = "ftp://example.com"):
+    # <expect-error>
+    urlopen(url12)
+
+def test12_ok(url12_ok = "sftp://example.com"):
+    # <no-error>
+    urlopen(url12_ok)
+
+
+def test13():
+    od = URLopener()
+    # <expect-error>
+    od.open("ftp://example.com")
+
+def test13_ok():
+    od = URLopener()
+    # <no-error>
+    od.open("ftps://example.com")
+
+def test14():
+    od = URLopener()
+    url14 = "ftp://example.com"
+    # <expect-error>
+    od.open(url14)
+
+def test14_ok():
+    od = URLopener()
+    # <no-error>
+    url14_ok = "ftps://example.com"
+    od.open(url14_ok)
+
+def test15():
+    # <expect-error>
+    URLopener().open("ftp://example.com")
+
+def test15_ok():
+    # <no-error>
+    URLopener().open("ftps://example.com")
+
+def test16():
+    url16 = "ftp://example.com"
+    # <expect-error>
+    URLopener().open(url16)
+
+def test16_ok():
+    # <no-error>
+    url16_ok = "ftps://example.com"
+    URLopener().open(url16_ok)
+
+def test17(url17 = "ftp://example.com"):
+    # <expect-error>
+    URLopener().open(url17)
+
+def test17_ok(url17_ok = "ftps://example.com"):
+    # <no-error>
+    URLopener().open(url17_ok)
+
+def test18(url18 = "ftp://example.com"):
+    od = URLopener()
+    # <expect-error>
+    od.open(url18)
+
+def test18_ok(url18_ok = "ftps://example.com"):
+    od = URLopener()
+    # <no-error>
+    od.open(url18_ok)
+
+def test19():
+    od = URLopener()
+    # <expect-error>
+    od.retrieve("ftp://example.com")
+
+def test19_ok():
+    od = URLopener()
+    # <no-error>
+    od.retrieve("ftps://example.com")
+
+def test20():
+    od = URLopener()
+    url20 = "ftp://example.com"
+    # <expect-error>
+    od.retrieve(url20)
+
+def test20_ok():
+    od = URLopener()
+    # <no-error>
+    url20_ok = "ftps://example.com"
+    od.retrieve(url20_ok)
+
+def test21():
+    # <expect-error>
+    URLopener().retrieve("ftp://example.com")
+
+def test21_ok():
+    # <no-error>
+    URLopener().retrieve("ftps://example.com")
+
+def test22():
+    url22 = "ftp://example.com"
+    # <expect-error>
+    URLopener().retrieve(url22)
+
+def test22_ok():
+    # <no-error>
+    url22_ok = "ftps://example.com"
+    URLopener().retrieve(url22_ok)
+
+def test23(url23 = "ftp://example.com"):
+    # <expect-error>
+    URLopener().retrieve(url23)
+
+def test23_ok(url23_ok = "ftps://example.com"):
+    # <no-error>
+    URLopener().retrieve(url23_ok)
+
+def test24(url24 = "ftp://example.com"):
+    od = URLopener()
+    # <expect-error>
+    od.retrieve(url24)
+
+def test24_ok(url24_ok = "ftps://example.com"):
+    od = URLopener()
+    # <no-error>
+    od.retrieve(url24_ok)
+
+def test25():
+    # <expect-error>
+    urlretrieve("ftp://example.com")
+
+def test25_ok():
+    # <no-error>
+    urlretrieve("sftp://example.com")
+
+def test26():
+    url26 = "ftp://example.com"
+    # <expect-error>
+    urlretrieve(url26)
+
+def test26_ok():
+    # <no-error>
+    url26_ok = "sftp://example.com"
+    urlretrieve(url26_ok)
+
+def test27(url27 = "ftp://example.com"):
+    # <expect-error>
+    urlretrieve(url27)
+
+# <no-error>
+def test28_ok(url28_ok = "sftp://example.com"):
+    urlretrieve(url28_ok)
+

--- a/checkers/python/use-ftp-tls.test.py
+++ b/checkers/python/use-ftp-tls.test.py
@@ -1,0 +1,10 @@
+import ftplib
+import ssl
+
+def bad():
+    # <expect-error>
+    ftpc = ftplib.FTP("example.com", "user", "pass")
+
+def ok():
+    # <no-error>
+    ftpc = ftplib.FTP_TLS("example.com", "user", "pass", context=ssl.create_default_context())

--- a/checkers/python/use-ftp-tls.yml
+++ b/checkers/python/use-ftp-tls.yml
@@ -1,0 +1,9 @@
+language: py
+name: use-ftp-tls
+message: Detected usage of `FTP` class which sends information unencrypted
+category: security
+
+pattern: >
+  (call
+    function: (attribute) @ftpFunc
+  (#match? @ftpFunc "^(ftplib.FTP|FTP)$")) @use-ftp-tls

--- a/checkers/python/use-ftp-tls.yml
+++ b/checkers/python/use-ftp-tls.yml
@@ -7,3 +7,6 @@ pattern: >
   (call
     function: (attribute) @ftpFunc
   (#match? @ftpFunc "^(ftplib.FTP|FTP)$")) @use-ftp-tls
+
+description: >
+  The `FTP` class transmits data unencrypted, making it vulnerable to interception. Use `FTP_TLS` instead for a secure, encrypted connection.


### PR DESCRIPTION
### Purpose

This PR adds checkers to detect insecure FTP connections. Using FTP links in `urllib` can cause security vulnerabilities as they are not encrypted. Using SFTP is a safer alternative. Since, `urllib` does not support SFTP, a different library must be used.

### Test logs

```
echo "Testing built-in rules..."
Testing built-in rules...
./bin/globstar test -d checkers
Running test case: avoid_add.yml
Running test case: avoid_latest.yml
Running test case: avoid_sudo.yml
Running test case: cgi_import.yml
Running test case: des_weak_crypto.yml
Running test case: fmt_print_in_prod.yml
Running test case: grpc_client_insecure_tls.yml
Running test case: grpc_server_insecure_tls.yml
Running test case: html_req_template_injection.yml
Running test case: http_file_server.yml
Running test case: insecure_cookie.yml
Running test case: jwt_harcoded_signing_key.yml
Running test case: jwt_none_algorithm.yml
Running test case: math_rand.yml
Running test case: md5_weak_hash.yml
Running test case: missing_error_file_open.yml
Running test case: mysql_conn_raw_passwd.yml
Running test case: net_bind_all_interfaces.yml
Running test case: os_create_file_default_permission.yml
Running test case: postgres_config_raw_passwd.yml
Running test case: postgres_conn_raw_passwd.yml
Running test case: pprof_endpoint_automatic_exposure.yml
Running test case: reflect_pkg.yml
Running test case: samesite_cookie.yml
Running test case: sha1_weak_hash.yml
Running test case: tls_config_minver.yml
Running test case: tls_insecure.yml
Running test case: unsafe_pkg.yml
Running test case: unsafe_path_traversal.yml
Running test case: dangerous_eval.yml
Running test case: avoid-marksafe.yml
Running test case: context-autoescape-off.yml
Running test case: filter-issafe.yml
Running test case: format-html-param.yml
Running test case: hashid-with-django-secret.yml
Running test case: safe-string-extend.yml
Running test case: use-ftp-tls.yml
Running test case: weak-ssl-version.yml
Running test case: blowfish_weak_crypto.yml
Running test case: dsa_weak_crypto.yml
Running test case: eval_method.yml
Running test case: md5_weak_hash.yml
Running test case: rails_force_ssl.yml
Running test case: rails_http_hardcoded_passwd.yml
Running test case: rails_httponly_cookie.yml
Running test case: rails_insecure_smtp.yml
Running test case: rails_samesite_cookie.yml
Running test case: rails_unsafe_direct_assignment.yml
Running test case: rsa_weak_crypto.yml
Running test case: sha1_weak_hash.yml
Running test case: skip_authorization.yml
Running test case: ssl_no_verify.yml
Running test case: avoid_unwrap.yml
Running tests in checkers/javascript/testdata for analyzers:
  Running tests for analyzer no-double-eq
  Running tests for analyzer sql_injection

Running tests in checkers/python/testdata for analyzers:
  Running tests for analyzer insecure-urllib-ftp

All tests passed%                           
``` 