### PR TITLE
checker: request tainted file write and request tainted `HttpResponse`/`HttpResponseBadRequest`

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -72,7 +72,7 @@ var AnalyzerRegistry = []Analyzer{
 	},
 	{
 		TestDir: "checkers/python/testdata",
-		Analyzers: []*goAnalysis.Analyzer{python.InsecureUrllibFtp},
+		Analyzers: []*goAnalysis.Analyzer{python.InsecureUrllibFtp, python.DjangoRequestDataWrite, python.DjangoRequestHttpResponse},
 	},
 }
 

--- a/checkers/python/django-request-data-write.go
+++ b/checkers/python/django-request-data-write.go
@@ -1,0 +1,232 @@
+package python
+
+import (
+	"regexp"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var DjangoRequestDataWrite *analysis.Analyzer = &analysis.Analyzer{
+	Name:        "django-request-data-write",
+	Language:    analysis.LangPy,
+	Description: "User-controlled request data is directly written to a file, which can lead to security risks such as unauthorized file modification, forced log rotation, or denial-of-service by exhausting disk space. Ensure proper input sanitization or escaping to mitigate these threats.",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityWarning,
+	Run:         checkDjangoRequestDataWrite,
+}
+
+func checkDjangoRequestDataWrite(pass *analysis.Pass) (interface{}, error) {
+	reqVarMap := make(map[string]bool)
+	intermVarMap := make(map[string]bool)
+
+	// get var names for data received from `request` calls
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "assignment" {
+			return
+		}
+
+		leftNode := node.ChildByFieldName("left")
+		rightNode := node.ChildByFieldName("right")
+
+		if rightNode == nil {
+			return
+		}
+
+		if isRequestCall(rightNode, pass.FileContext.Source) {
+			reqVarMap[leftNode.Content(pass.FileContext.Source)] = true
+		}
+	})
+
+	// get var names for data formatted by user data
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "assignment" {
+			return
+		}
+
+		leftNode := node.ChildByFieldName("left")
+		rightNode := node.ChildByFieldName("right")
+
+		if rightNode == nil {
+			return
+		}
+
+		if isUserTainted(rightNode, pass.FileContext.Source, intermVarMap, reqVarMap) {
+			intermVarMap[leftNode.Content(pass.FileContext.Source)] = true
+		}
+	})
+
+	// catch insecure file write methods
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "call" {
+			return
+		}
+
+		funcNode := node.ChildByFieldName("function")
+		if funcNode.Type() != "attribute" && funcNode.Type() != "identifier" {
+			return
+		}
+
+		if !strings.HasSuffix(funcNode.Content(pass.FileContext.Source), "write") {
+			return
+		}
+
+		argListNode := node.ChildByFieldName("arguments")
+		if argListNode.Type() != "argument_list" {
+			return
+		}
+
+		argNodes := getNamedChildren(argListNode, 0)
+		for _, arg := range argNodes {
+			if isUserTainted(arg, pass.FileContext.Source, intermVarMap, reqVarMap) {
+				pass.Report(pass, node, "User-controlled data written to a file may enable log tampering, forced rotation, or disk exhaustion—sanitize input before writing")
+			}
+		}
+
+	})
+
+	return nil, nil
+}
+
+func isUserTainted(node *sitter.Node, source []byte, intermVarMap, reqVarMap map[string]bool) bool {
+	switch node.Type() {
+	case "call":
+		if isInFunc(node, source, intermVarMap, reqVarMap) {
+			return true
+		}
+		functionNode := node.ChildByFieldName("function")
+		if functionNode.Type() != "attribute" {
+			return false
+		}
+
+		if !strings.HasSuffix(functionNode.Content(source), ".format") {
+			return false
+		}
+
+		argListNode := node.ChildByFieldName("arguments")
+		if argListNode.Type() != "argument_list" {
+			return false
+		}
+
+		argsNode := getNamedChildren(argListNode, 0)
+		for _, arg := range argsNode {
+			if arg.Type() == "identifier" && reqVarMap[arg.Content(source)] {
+				return true
+			} else if arg.Type() == "call" && isRequestCall(arg, source) {
+				return true
+			}
+		}
+
+	case "string":
+		if node.Content(source)[0] != 'f' {
+			return false
+		}
+		stringChildrenNodes := getNamedChildren(node, 0)
+		for _, strnode := range stringChildrenNodes {
+			if strnode.Type() == "interpolation" {
+				exprnode := strnode.ChildByFieldName("expression")
+				if exprnode.Type() == "identifier" && reqVarMap[exprnode.Content(source)] {
+					return true
+				} else if exprnode.Type() == "call" && isRequestCall(exprnode, source) {
+					return true
+				}
+			}
+		}
+
+	case "binary_operator":
+		binOpStr := node.Content(source)
+
+		for reqvar := range reqVarMap {
+			pattern := `\b` + reqvar + `\b`
+			re := regexp.MustCompile(pattern)
+
+			if re.MatchString(binOpStr) {
+				return true
+			}
+		}
+
+		rightNode := node.ChildByFieldName("right")
+		if rightNode.Type() == "call" && isRequestCall(rightNode, source) {
+			return true
+		} else if rightNode.Type() == "tuple" {
+			targsNode := getNamedChildren(rightNode, 0)
+			for _, targ := range targsNode {
+				if targ.Type() == "identifier" && reqVarMap[targ.Content(source)] {
+					return true
+				} else if targ.Type() == "call" && isRequestCall(targ, source) {
+					return true
+				}
+			}
+		}
+
+	case "identifier":
+		return reqVarMap[node.Content(source)] || intermVarMap[node.Content(source)]
+
+	case "subscript":
+		return isRequestCall(node, source)
+	}
+
+	return false
+}
+
+func isInFunc(node *sitter.Node, source []byte, intermVarMap, reqvarmap map[string]bool) bool {
+	if node.Type() != "call" {
+		return false
+	}
+	if strings.HasSuffix(node.Content(source), ".format") {
+		return false
+	}
+	argListNode := node.ChildByFieldName("arguments")
+	if argListNode.Type() != "argument_list" {
+		return false
+	}
+	argNodes := getNamedChildren(argListNode, 0)
+
+	for _, arg := range argNodes {
+		if isUserTainted(arg, source, intermVarMap, reqvarmap) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRequestCall(node *sitter.Node, source []byte) bool {
+	switch node.Type() {
+	case "call":
+		funcNode := node.ChildByFieldName("function")
+		if funcNode.Type() != "attribute" {
+			return false
+		}
+		objectNode := funcNode.ChildByFieldName("object")
+		if !strings.Contains(objectNode.Content(source), "request") {
+			return false
+		}
+
+		attributeNode := funcNode.ChildByFieldName("attribute")
+		if attributeNode.Type() != "identifier" {
+			return false
+		}
+
+		if !strings.Contains(attributeNode.Content(source), "get") {
+			return false
+		}
+
+		return true
+
+	case "subscript":
+		valueNode := node.ChildByFieldName("value")
+		if valueNode.Type() != "attribute" {
+			return false
+		}
+
+		objNode := valueNode.ChildByFieldName("object")
+		if objNode.Type() != "identifier" && objNode.Content(source) != "request" {
+			return false
+		}
+
+		return true
+	}
+
+	return false
+}

--- a/checkers/python/django-request-httpresponse.go
+++ b/checkers/python/django-request-httpresponse.go
@@ -1,0 +1,167 @@
+package python
+
+import (
+	"strings"
+	"regexp"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"globstar.dev/analysis"
+)
+
+var DjangoRequestHttpResponse *analysis.Analyzer = &analysis.Analyzer{
+	Name:        "django-request-httpresponse",
+	Language:    analysis.LangPy,
+	Description: "User-controlled data in `HttpResponse` may enable XSS, allowing attackers to steal cookies or sensitive data. Escape or sanitize input to prevent script injection. Use secure templating or built-in encoding to mitigate risks.",
+	Category:    analysis.CategorySecurity,
+	Severity:    analysis.SeverityWarning,
+	Run:         checkDjangoRequestHttpResponse,
+}
+
+func checkDjangoRequestHttpResponse(pass *analysis.Pass) (interface{}, error) {
+	reqVarMap := make(map[string]bool)
+	intermVarMap := make(map[string]bool)
+
+	// get var names for data received from `request` calls
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "assignment" {
+			return
+		}
+
+		leftNode := node.ChildByFieldName("left")
+		rightNode := node.ChildByFieldName("right")
+
+		if rightNode == nil {
+			return
+		}
+
+		if isRequestCall(rightNode, pass.FileContext.Source) {
+			reqVarMap[leftNode.Content(pass.FileContext.Source)] = true
+		}
+	})
+
+	// get var names for data formatted by user data
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "assignment" {
+			return
+		}
+
+		leftNode := node.ChildByFieldName("left")
+		rightNode := node.ChildByFieldName("right")
+
+		if rightNode == nil {
+			return
+		}
+
+		if isUserTaintedHttpResp(rightNode, pass.FileContext.Source, intermVarMap, reqVarMap) {
+			intermVarMap[leftNode.Content(pass.FileContext.Source)] = true
+		}
+	})
+
+	// catch insecure HttpResponse and HttpResponseBadRequest calls
+	analysis.Preorder(pass, func(node *sitter.Node) {
+		if node.Type() != "call" {
+			return
+		}
+
+		funcNode := node.ChildByFieldName("function")
+		if funcNode.Type() != "attribute" && funcNode.Type() != "identifier" {
+			return
+		}
+		
+		if !strings.HasSuffix(funcNode.Content(pass.FileContext.Source), "HttpResponse") && !strings.HasSuffix(funcNode.Content(pass.FileContext.Source), "HttpResponseBadRequest") {
+			return
+		}
+		
+		argListNode := node.ChildByFieldName("arguments")
+		if argListNode.Type() != "argument_list" {
+			return
+		}
+
+		argNodes := getNamedChildren(argListNode, 0)
+		for _, arg := range argNodes {
+			if isUserTaintedHttpResp(arg, pass.FileContext.Source, intermVarMap, reqVarMap) {
+				pass.Report(pass, node, "User-controlled data in `HttpResponse`/`HttpResponseBadRequest` may lead to XSS—escape or sanitize input to prevent script injection and data exposure.")
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func isUserTaintedHttpResp(node *sitter.Node, source []byte, intermVarMap, reqVarMap map[string]bool) bool {
+	switch node.Type() {
+	case "call":
+		functionNode := node.ChildByFieldName("function")
+		if functionNode.Type() != "attribute" {
+			return false
+		}
+
+		if !strings.HasSuffix(functionNode.Content(source), ".format") {
+			return false
+		}
+
+		argListNode := node.ChildByFieldName("arguments")
+		if argListNode.Type() != "argument_list" {
+			return false
+		}
+
+		argsNode := getNamedChildren(argListNode, 0)
+		for _, arg := range argsNode {
+			if arg.Type() == "identifier" && reqVarMap[arg.Content(source)] {
+				return true
+			} else if arg.Type() == "call" && isRequestCall(arg, source) {
+				return true
+			}
+		}
+
+	case "string":
+		if node.Content(source)[0] != 'f' {
+			return false
+		}
+		stringChildrenNodes := getNamedChildren(node, 0)
+		for _, strnode := range stringChildrenNodes {
+			if strnode.Type() == "interpolation" {
+				exprnode := strnode.ChildByFieldName("expression")
+				if exprnode.Type() == "identifier" && reqVarMap[exprnode.Content(source)] {
+					return true
+				} else if exprnode.Type() == "call" && isRequestCall(exprnode, source) {
+					return true
+				}
+			}
+		}
+
+	case "binary_operator":
+		binOpStr := node.Content(source)
+
+		for reqvar := range reqVarMap {
+			pattern := `\b` + reqvar + `\b`
+			re := regexp.MustCompile(pattern)
+
+			if re.MatchString(binOpStr) {
+				return true
+			}
+		}
+
+		rightNode := node.ChildByFieldName("right")
+		if rightNode.Type() == "call" && isRequestCall(rightNode, source) {
+			return true
+		} else if rightNode.Type() == "tuple" {
+			targsNode := getNamedChildren(rightNode, 0)
+			for _, targ := range targsNode {
+				if targ.Type() == "identifier" && reqVarMap[targ.Content(source)] {
+					return true
+				} else if targ.Type() == "call" && isRequestCall(targ, source) {
+					return true
+				}
+			}
+		}
+
+	case "identifier":
+		return reqVarMap[node.Content(source)] || intermVarMap[node.Content(source)]
+
+	case "subscript":
+		return isRequestCall(node, source)
+	}
+
+	return false
+}

--- a/checkers/python/testdata/django-request-data-write.test.py
+++ b/checkers/python/testdata/django-request-data-write.test.py
@@ -1,0 +1,50 @@
+import time
+from django.contrib.auth.models import User
+from django.http import HttpResponse
+from . import settings as USettings
+
+def save_scrawl_file(request, filename):
+    import base64
+    try:
+        content = request.POST.get(USettings.UEditorUploadSettings.get("scrawlFieldName", "upfile"))
+        f = open(filename, 'wb')
+        # <expect-error>
+        f.write(base64.decodestring(content))
+        f.close()
+        state = "SUCCESS"
+    except Exception as e:
+        state = u"写入图片文件错误:%s" % e
+    return state
+
+def save_file(request):
+    # <no-error>
+    user = User.objects.get(username=request.session.get('user'))
+    content_safe = "user logged in at {}".format(time.time())
+    f = open("{}-{}".format(user, time.time()), 'wb')
+    f.write(content_safe)
+    f.close()
+
+
+def with_interm_var(request, filename):
+    data = request.POST.get("data")
+    f = open(filename, "r")
+    formatted_data = "This is the {}".format(data)
+    # <expect-error>
+    f.write(formatted_data)
+    f.close()
+
+def with_interm_var(request, filename):
+    data = request.POST.get("data")
+    f = open(filename, "r")
+    formatted_data = "This is the {}" % data
+    # <expect-error>
+    f.write(formatted_data)
+    f.close()
+
+def with_interm_var(request, filename):
+    data = request.POST.get("data")
+    f = open(filename, "r")
+    formatted_data = f"This is the {data}"
+    # <expect-error>
+    f.write(formatted_data)
+    f.close()

--- a/checkers/python/testdata/django-request-httpresponse.test.py
+++ b/checkers/python/testdata/django-request-httpresponse.test.py
@@ -1,0 +1,75 @@
+import urllib
+from django.db.models import Q
+from django.auth import User
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils.translation import ugettext as _
+
+def search_certificates(request):
+    user_filter = request.GET.get("user", "")
+    if not user_filter:
+        msg = _("user is not given.")
+        return HttpResponseBadRequest(msg)
+
+
+    user = User.objects.get(Q(email=user_filter) | Q(username=user_filter))
+    if user.DoesNotExist:
+        # <expect-error>
+        return HttpResponseBadRequest(_("user '{user}' does not exist").format(user_filter))
+
+def previewNode(request, uid):
+    """Preview evaluante node"""
+    try:
+        if uid in engines:
+            _nodeId = request.data.get('nodeId')
+            engines[uid].stoppable = True
+            _res = engines[uid].model.previewNode(_nodeId)
+            if _res is None:
+                # <no-error>
+                return HttpResponseBadRequest('', status=204)
+            # <no-error>
+            return HttpResponseBadRequest(_res)
+        return manageNoEngine()
+    except Exception as e:
+        return genericApiException(e, engines[uid])
+    finally:
+        engines[uid].stoppable = False
+
+def inline_test(request):
+    # <expect-error>
+    return HttpResponseBadRequest("Received {}".format(request.POST.get('message')))
+
+
+def search_certificates(request):
+    user_filter = request.GET.get("user", "")
+    if not user_filter:
+        msg = _("user is not given.")
+        # <no-error>
+        return HttpResponseBadRequest(msg)
+
+
+    user = User.objects.get(Q(email=user_filter) | Q(username=user_filter))
+    if user.DoesNotExist:
+        # <expect-error>
+        return HttpResponse(_("user '{user}' does not exist").format(user_filter))
+
+def previewNode(request, uid):
+    """Preview evaluante node"""
+    try:
+        if uid in engines:
+            _nodeId = request.data.get('nodeId')
+            engines[uid].stoppable = True
+            _res = engines[uid].model.previewNode(_nodeId)
+            if _res is None:
+                # <no-error>
+                return HttpResponse('', status=204)
+            # <no-error>
+            return HttpResponse(_res)
+        return manageNoEngine()
+    except Exception as e:
+        return genericApiException(e, engines[uid])
+    finally:
+        engines[uid].stoppable = False
+
+def inline_test(request):
+    # <expect-error>
+    return HttpResponse("Received {}".format(request.POST.get('message')))


### PR DESCRIPTION
## Purpose

This PR adds checker for the following:

- `file.write()` method call tainted with dynamic data from a `request` call
- `HttpResponse` and `HttpResponseBadRequest` tainted with dynamic data from `request` call