### PR TITLE
checker: detect miscellaneous graphql vulns

### DIFF
--- a/checkers/javascript/graphql-no-csrf-prevention.test.js
+++ b/checkers/javascript/graphql-no-csrf-prevention.test.js
@@ -1,0 +1,22 @@
+// OK: Lacks 'csrfPrevention: true', but on v4 this option is true by default
+//ok: v4-csrf-prevention
+const apollo_server_1 = new ApolloServer({
+    typeDefs,
+    resolvers,
+});
+
+// Good: Has 'csrfPrevention: true'
+//ok: v4-csrf-prevention
+const apollo_server_3 = new ApolloServer({
+    typeDefs,
+    resolvers,
+    csrfPrevention: true,
+});
+
+// BAD: Has 'csrfPrevention: false'
+// <expect-error>
+const apollo_server_2 = new ApolloServer({
+    typeDefs,
+    resolvers,
+    csrfPrevention: false,
+});

--- a/checkers/javascript/graphql-no-csrf-prevention.yml
+++ b/checkers/javascript/graphql-no-csrf-prevention.yml
@@ -1,0 +1,19 @@
+language: javascript
+name: graphql-no-csrf-prevention
+message: "Apollo GraphQL server vulnerable to CSRF attacks due to `csrfPrevention: false` setting"
+category: security
+severity: error
+
+pattern: >
+  (new_expression
+    constructor: (identifier) @apolloServer (#eq? @apolloServer "ApolloServer")
+    arguments: (arguments
+      (object
+        (_)*
+        (pair
+          key: (property_identifier) @csrf (#eq? @csrf "csrfPrevention")
+          value: (false))
+        (_)*)
+      )) @graphql-no-csrf-prevention
+
+description: Apollo GraphQL server has disabled CSRF protection by setting 'csrfPrevention' to false, making the server vulnerable to Cross-Site Request Forgery attacks. This configuration allows malicious websites to make unauthorized requests using authenticated users' credentials.

--- a/checkers/javascript/graphql-schema-directives.test.js
+++ b/checkers/javascript/graphql-schema-directives.test.js
@@ -1,0 +1,14 @@
+// <expect-error>
+const apollo_server_1 = new ApolloServer({
+    typeDefs,
+    resolvers,
+    schemaDirectives: {
+        rateLimit: rateLimitDirective
+    },
+});
+
+// <no-error>
+const apollo_server_3 = new ApolloServer({
+    typeDefs,
+    resolvers,
+});

--- a/checkers/javascript/graphql-schema-directives.yml
+++ b/checkers/javascript/graphql-schema-directives.yml
@@ -1,0 +1,22 @@
+language: javascript
+name: graphql-schema-directives
+message: "Apollo GraphQL using deprecated 'schemaDirectives' that silently fail in v3+, potentially exposing endpoints."
+category: security
+severity: error
+
+pattern: >
+  (new_expression
+    constructor: (identifier) @apolloServer (#eq? @apolloServer "ApolloServer")
+    arguments: (arguments
+      (object
+        (_)*
+        (pair
+          key: (property_identifier) @schema
+          value: (_))
+        (_)*
+      )
+    )
+    (#eq? @schema "schemaDirectives")) @graphql-schema-directives
+
+description: >
+  Apollo GraphQL's 'schemaDirectives' option works in v2 but silently fails in v3+, potentially exposing authenticated endpoints and disabling security controls. This silent failure creates security risks as configured directives provide no protection. Refer to v3/v4 documentation to properly implement custom directives.

--- a/checkers/javascript/graphql-upload.test.js
+++ b/checkers/javascript/graphql-upload.test.js
@@ -1,0 +1,2 @@
+// <expect-error>
+app.use(graphqlUploadExpress());

--- a/checkers/javascript/graphql-upload.yml
+++ b/checkers/javascript/graphql-upload.yml
@@ -1,0 +1,21 @@
+language: javascript
+name: graphql-upload
+message: "Using graphql upload library can cause CSRF attacks"
+category: security
+severity: warning
+
+pattern: >
+  (call_expression
+    function: (member_expression) @funcCall
+    arguments: (arguments
+      (_)*
+      (call_expression
+        function: (identifier) @gqlupload)
+      (_)*
+    )
+    (#eq? @funcCall "app.use")
+    (#eq? @gqlupload "graphqlUploadExpress")) @graphql-upload
+
+
+description: >
+  The Apollo GraphQL server using graphql-upload library enables file uploads via multipart/form-data POSTs, creating CSRF vulnerabilities. This occurs because multipart/form-data requests bypass same-origin protections. If graphql-upload is necessary for your application, implement CSRF protection measures to secure your server.


### PR DESCRIPTION
## Purpose

This PR adds checkers to detect the following vulnerabilities

- Using `graphql-upload` library which can cause CSRF vulnerabilities.
- Using the `schemaDirective` option in `ApolloServer` which is deprecated in v3+ and silently fails, leading to potential endpoint exposure vulnerabilties
- Setting the `csrfPrevention` option to false in `ApolloServer`, opening up to potential CSRF attacks.