### PR TITLE
enh: support multiple checker ids in skipcq directive

### DIFF
--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -250,7 +250,8 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 	var skipLines []*SkipComment
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
-	pattern := fmt.Sprintf(`%s\s+skipcq(?::\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*))?\s*`, commentIdentifier)
+	pattern := fmt.Sprintf(`%s(?i).*?\bskipcq\b(?::(?:\s*(?P<issue_ids>([A-Za-z\-_0-9]*(?:,\s*)?)+))?)?`, commentIdentifier)
+
 	skipRegexp := regexp.MustCompile(pattern)
 
 	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
@@ -328,14 +329,14 @@ func ContainsSkipcq(skipLines []*SkipComment, issue *Issue) bool {
 			continue
 		}
 
-		if len(comment.CheckerIds) > 0 {
-			for _, id := range comment.CheckerIds {
-				if checkerId == id {
-					return true
-				}
-			}
-		} else {
+		if len(comment.CheckerIds) == 0 {
 			return true
+		}
+
+		for _, id := range comment.CheckerIds {
+			if checkerId == id {
+				return true
+			}
 		}
 	}
 

--- a/analysis/analyzer.go
+++ b/analysis/analyzer.go
@@ -251,7 +251,7 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
 	pattern := fmt.Sprintf(`%s\s+skipcq(?::\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*))?\s*`, commentIdentifier)
-    skipRegexp := regexp.MustCompile(pattern)
+	skipRegexp := regexp.MustCompile(pattern)
 
 	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
 		Grammar())
@@ -299,10 +299,10 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 				skipLines = append(skipLines, &SkipComment{
 					CommentLine: commentLine,
 					CommentText: commentText,
-					CheckerIds: checkerIds, // will be empty for generic skipcq
+					CheckerIds:  checkerIds, // will be empty for generic skipcq
 				})
 			}
-			
+
 		}
 	}
 

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -98,6 +98,30 @@ func TestSkipCqComment(t *testing.T) {
 			checker:  mockChecker,
 			want:     false,
 		},
+		{
+			name:      "skipcq with multiple targets matching",
+			checkerId: "no-assert",
+			filename:  "no-assert.test.py",
+			source: `
+				# skipcq: no-assert, csv-writer
+				assert a == c
+			`,
+			language: LangPy,
+			checker:  mockChecker,
+			want:     true,
+		},
+		{
+			name:      "skipcq with multiple targets mismatch",
+			checkerId: "no-assert",
+			filename:  "file.py",
+			source: `
+				# skipcq: sql-inject, flask-taint
+				assert 1 == 10
+			`,
+			language: LangPy,
+			checker:  mockChecker,
+			want:     false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -128,6 +128,7 @@ func TestSkipCqComment(t *testing.T) {
 			filename:  "no-assert.test.py",
 			source: `
 				def someFunc():
+					# some comment
 					assert a == b # assert statement skipcq: no-assert, sql-inject should skip # nosec
 			`,
 			language: LangPy,

--- a/analysis/analyzer_test.go
+++ b/analysis/analyzer_test.go
@@ -122,6 +122,41 @@ func TestSkipCqComment(t *testing.T) {
 			checker:  mockChecker,
 			want:     false,
 		},
+		{
+			name:      "skipcq with extra comments matching targets",
+			checkerId: "no-assert",
+			filename:  "no-assert.test.py",
+			source: `
+				def someFunc():
+					assert a == b # assert statement skipcq: no-assert, sql-inject should skip # nosec
+			`,
+			language: LangPy,
+			checker:  mockChecker,
+			want:     true,
+		},
+		{
+			name:      "skipcq with extra comments no matching targets",
+			checkerId: "no-assert",
+			filename:  "no-assert.test.py",
+			source: `
+				assert 1 > 2 # random comment skipcq: unused-import, csv-writer, django-injection // more comment
+			`,
+			language: LangPy,
+			checker:  mockChecker,
+			want:     false,
+		},
+		{
+			name:      "skipcq with extra comments no target",
+			checkerId: "no-assert",
+			filename:  "no-assert.test.py",
+			source: `
+				def someFunc():
+					assert a == b # some comment skipcq # nosec
+			`,
+			language: LangPy,
+			checker:  mockChecker,
+			want:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -348,7 +348,7 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
 	pattern := fmt.Sprintf(`%s\s+skipcq(?::\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*))?\s*`, commentIdentifier)
-    skipRegexp := regexp.MustCompile(pattern)
+	skipRegexp := regexp.MustCompile(pattern)
 
 	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
 		Grammar())
@@ -396,10 +396,10 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 				skipLines = append(skipLines, &SkipComment{
 					CommentLine: commentLine,
 					CommentText: commentText,
-					CheckerIds: checkerIds, // will be empty for generic skipcq
+					CheckerIds:  checkerIds, // will be empty for generic skipcq
 				})
 			}
-			
+
 		}
 	}
 

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"globstar.dev/pkg/config"
@@ -100,7 +101,7 @@ type SkipComment struct {
 	// the entire text of the skipcq comment
 	CommentText string
 	// (optional) name of the checker for targetted skip
-	CheckerId string
+	CheckerId []string
 }
 
 // package level cache to store comments for each file
@@ -342,14 +343,19 @@ func RunYamlCheckers(path string, analyzers []*Analyzer) ([]*Issue, error) {
 	return issues, nil
 }
 
+// cache all the skipcq comments from an ast
 func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 	var skipLines []*SkipComment
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
-	pattern := fmt.Sprintf(`^%s\s+skipcq(?::\s*([A-Za-z0-9_-]+))?`, commentIdentifier)
-	skipRegexp := regexp.MustCompile(pattern)
+	basePattern := fmt.Sprintf(`^%s\s+skipcq\s*$`, commentIdentifier)
+	baseRegexp := regexp.MustCompile(basePattern)
 
-	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.Grammar())
+	checkerPattern := fmt.Sprintf(`%s\s+skipcq:\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*)`, commentIdentifier)
+	checkerRegexp := regexp.MustCompile(checkerPattern)
+
+	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
+		Grammar())
 
 	if err != nil {
 		return skipLines
@@ -375,20 +381,37 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 			commentLine := int(commentNode.StartPoint().Row)
 			commentText := commentNode.Content(fileContext.Source)
 
-			// look for checker names
-			matches := skipRegexp.FindStringSubmatch(commentText)
-			var checkerId string
+			matches := checkerRegexp.FindStringSubmatch(commentText)
 			if matches != nil {
-				if len(matches) > 1 {
-					checkerId = matches[1]
+				issueIdx := checkerRegexp.SubexpIndex("issue_ids")
+				if issueIdx != -1 && issueIdx < len(matches) {
+					issueIdStr := matches[issueIdx]
+
+					var checkerIds []string
+					if issueIdStr != "" {
+						idSlice := strings.Split(issueIdStr, ",")
+						for _, id := range idSlice {
+							trimmedId := strings.TrimSpace(id)
+							if trimmedId != "" {
+								checkerIds = append(checkerIds, trimmedId)
+							}
+						}
+					}
+
+					skipLines = append(skipLines, &SkipComment{
+						CommentLine: commentLine,
+						CommentText: commentText,
+						CheckerId:   checkerIds,
+					})
+					continue
 				}
 			}
 
-			if skipRegexp.MatchString(commentText) {
+			if baseRegexp.MatchString(commentText) {
 				skipLines = append(skipLines, &SkipComment{
 					CommentLine: commentLine,
 					CommentText: commentText,
-					CheckerId: checkerId, // will be empty for generic skipcq
+					CheckerId:   nil,
 				})
 			}
 		}
@@ -407,7 +430,6 @@ func (ana *Analyzer) ContainsSkipcq(skipLines []*SkipComment, issue *Issue) bool
 	prevLine := nodeLine - 1
 
 	var checkerId string
-
 	if issue.Id != nil {
 		checkerId = *issue.Id
 	}
@@ -417,13 +439,14 @@ func (ana *Analyzer) ContainsSkipcq(skipLines []*SkipComment, issue *Issue) bool
 			continue
 		}
 
-		if comment.CheckerId != "" {
-			// targetted skipcq
-			if checkerId == comment.CheckerId {
-				return true
+		if len(comment.CheckerId) > 0 {
+			for _, id := range comment.CheckerId {
+				if checkerId == id {
+					return true
+				}
 			}
 		} else {
-			return true // generic skipcq
+			return true
 		}
 	}
 

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -101,7 +101,7 @@ type SkipComment struct {
 	// the entire text of the skipcq comment
 	CommentText string
 	// (optional) name of the checker for targetted skip
-	CheckerId []string
+	CheckerIds []string
 }
 
 // package level cache to store comments for each file
@@ -343,16 +343,12 @@ func RunYamlCheckers(path string, analyzers []*Analyzer) ([]*Issue, error) {
 	return issues, nil
 }
 
-// cache all the skipcq comments from an ast
 func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 	var skipLines []*SkipComment
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
-	basePattern := fmt.Sprintf(`^%s\s+skipcq\s*$`, commentIdentifier)
-	baseRegexp := regexp.MustCompile(basePattern)
-
-	checkerPattern := fmt.Sprintf(`%s\s+skipcq:\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*)`, commentIdentifier)
-	checkerRegexp := regexp.MustCompile(checkerPattern)
+	pattern := fmt.Sprintf(`%s\s+skipcq(?::\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*))?\s*`, commentIdentifier)
+    skipRegexp := regexp.MustCompile(pattern)
 
 	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
 		Grammar())
@@ -381,39 +377,29 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 			commentLine := int(commentNode.StartPoint().Row)
 			commentText := commentNode.Content(fileContext.Source)
 
-			matches := checkerRegexp.FindStringSubmatch(commentText)
+			matches := skipRegexp.FindStringSubmatch(commentText)
 			if matches != nil {
-				issueIdx := checkerRegexp.SubexpIndex("issue_ids")
-				if issueIdx != -1 && issueIdx < len(matches) {
-					issueIdStr := matches[issueIdx]
+				issueIdsIdx := skipRegexp.SubexpIndex("issue_ids")
+				var checkerIds []string
 
-					var checkerIds []string
-					if issueIdStr != "" {
-						idSlice := strings.Split(issueIdStr, ",")
-						for _, id := range idSlice {
-							trimmedId := strings.TrimSpace(id)
-							if trimmedId != "" {
-								checkerIds = append(checkerIds, trimmedId)
-							}
+				if issueIdsIdx != -1 && issueIdsIdx < len(matches) && matches[issueIdsIdx] != "" {
+					issueIdsIdx := matches[issueIdsIdx]
+					idSlice := strings.Split(issueIdsIdx, ",")
+					for _, id := range idSlice {
+						trimmedId := strings.TrimSpace(id)
+						if trimmedId != "" {
+							checkerIds = append(checkerIds, trimmedId)
 						}
 					}
-
-					skipLines = append(skipLines, &SkipComment{
-						CommentLine: commentLine,
-						CommentText: commentText,
-						CheckerId:   checkerIds,
-					})
-					continue
 				}
-			}
 
-			if baseRegexp.MatchString(commentText) {
 				skipLines = append(skipLines, &SkipComment{
 					CommentLine: commentLine,
 					CommentText: commentText,
-					CheckerId:   nil,
+					CheckerIds: checkerIds, // will be empty for generic skipcq
 				})
 			}
+			
 		}
 	}
 
@@ -439,8 +425,8 @@ func (ana *Analyzer) ContainsSkipcq(skipLines []*SkipComment, issue *Issue) bool
 			continue
 		}
 
-		if len(comment.CheckerId) > 0 {
-			for _, id := range comment.CheckerId {
+		if len(comment.CheckerIds) > 0 {
+			for _, id := range comment.CheckerIds {
 				if checkerId == id {
 					return true
 				}

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -347,7 +347,7 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 	var skipLines []*SkipComment
 
 	commentIdentifier := GetEscapedCommentIdentifierFromPath(fileContext.FilePath)
-	pattern := fmt.Sprintf(`%s\s+skipcq(?::\s*(?P<issue_ids>([a-z0-9\-_]+(?:,(\s+)?)?)*))?\s*`, commentIdentifier)
+	pattern := fmt.Sprintf(`%s(?i).*?\bskipcq\b(?::(?:\s*(?P<issue_ids>([A-Za-z\-_0-9]*(?:,\s*)?)+))?)?`, commentIdentifier)
 	skipRegexp := regexp.MustCompile(pattern)
 
 	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.

--- a/pkg/analysis/analyze.go
+++ b/pkg/analysis/analyze.go
@@ -350,8 +350,7 @@ func GatherSkipInfo(fileContext *ParseResult) []*SkipComment {
 	pattern := fmt.Sprintf(`%s(?i).*?\bskipcq\b(?::(?:\s*(?P<issue_ids>([A-Za-z\-_0-9]*(?:,\s*)?)+))?)?`, commentIdentifier)
 	skipRegexp := regexp.MustCompile(pattern)
 
-	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.
-		Grammar())
+	query, err := sitter.NewQuery([]byte("(comment) @skipcq"), fileContext.Language.Grammar())
 
 	if err != nil {
 		return skipLines

--- a/pkg/analysis/analyze_test.go
+++ b/pkg/analysis/analyze_test.go
@@ -73,6 +73,25 @@ func TestSkipCq(t *testing.T) {
 			`,
 			want: false,
 		},
+		{
+			name:      "skipcq with multiple targets matching",
+			checkerId: "no-assert",
+			language:  LangPy,
+			source: `
+				# skipcq: csv-writer, no-assert
+				assert 1 == 10
+			`,
+			want: true,
+		},
+		{
+			name:      "skipcq with multiple targets mismatching",
+			checkerId: "no-assert",
+			language:  LangPy,
+			source: `
+				assert 2==1 # skipcq: csv-writer, flask-error
+			`,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/analysis/analyze_test.go
+++ b/pkg/analysis/analyze_test.go
@@ -92,6 +92,35 @@ func TestSkipCq(t *testing.T) {
 			`,
 			want: false,
 		},
+		{
+			name:      "skipcq with extra comments target match",
+			checkerId: "no-assert",
+			language:  LangPy,
+			source: `
+				def aFunc():
+					assert a == b # some comment skipcq: no-assert, sql-inject # nosec,
+			`,
+			want: true,
+		},
+		{
+			name:      "skipcq with extra comments target unmatched",
+			checkerId: "no-assert",
+			language:  LangPy,
+			source: `
+				assert a is b # should be true skipcq: sql-inject, django-taint # more
+			`,
+			want: false,
+		},
+		{
+			name:      "skipcq with extra comments no target",
+			checkerId: "no-assert",
+			language:  LangPy,
+			source: `
+				if True:
+					assert 1 == 2 # must be false skipcq # nosec,
+			`,
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`skipcq` comments can now take more than target checker name to suppress