### PR TITLE
feat: Add initial 'py-no-else-after-return' rule

### DIFF
--- a/checkers/py-no-else-after-return.test.py
+++ b/checkers/py-no-else-after-return.test.py
@@ -1,0 +1,54 @@
+# Test cases for py-no-else-after-return
+
+# Case 1: Violation - simple if/else with return
+def foo(x):
+    if x > 0:
+        return "positive"
+    else: # This 'else' is unnecessary
+        return "non-positive"
+
+# Case 2: Violation - if/elif/else with return in if
+# Note: The current pattern might not be smart enough to catch this if the `elif` is present.
+# We will see if the pattern needs adjustment.
+def bar(x):
+    if x > 10:
+        return "large"
+    elif x > 5:
+        print("medium")
+    else: # This 'else' is unnecessary if the first 'if' returns
+        return "small"
+
+# Case 3: No violation - if without else
+def baz(x):
+    if x:
+        return True
+    print("after if")
+    return False
+
+# Case 4: No violation - if/else but no return in the if block
+def qux(x):
+    if x:
+        print("x is true")
+    else:
+        print("x is false")
+    return None
+
+# Case 5: Violation - if with multiple statements and return, then else
+def corge(y):
+    if y == 1:
+        print("one")
+        return "uno"
+    else: # Unnecessary
+        print("not one")
+        return "no uno"
+
+# Case 6: No violation - if/elif/else where if and elif don't always return
+def grault(z):
+    if z > 100:
+        if z > 200:
+            return "very large"
+        print("still large")
+    elif z > 50:
+        return "medium"
+    else:
+        return "small" # This else is necessary

--- a/checkers/py-no-else-after-return.yml
+++ b/checkers/py-no-else-after-return.yml
@@ -1,0 +1,9 @@
+language: py
+id: py-no-else-after-return
+name: no-else-after-return # Added name for consistency with other yml files
+severity: warning
+message: "Unnecessary 'else' after 'return'. The 'if' block always returns."
+category: antipattern # Added category
+description: |
+  An 'else' block is not necessary if the 'if' block unconditionally returns or raises.
+  This improves readability by reducing nesting.

--- a/pkg/rules/python/no_else_after_return.go
+++ b/pkg/rules/python/no_else_after_return.go
@@ -1,0 +1,86 @@
+package python_rules
+
+import (
+	"github.com/DeepSourceCorp/globstar/pkg/analysis"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// isReturnStatement checks if a node is a return statement.
+func isReturnStatement(node *sitter.Node) bool {
+	return node.Type() == "return_statement"
+}
+
+// blockAlwaysReturns checks if a block of statements always ends in a return.
+// This is a simplified check: it looks for a return statement as one of
+// the direct children of the block. More complex analysis (e.g. if/else within
+// the block where both branches return) is not handled by this initial version.
+func blockAlwaysReturns(blockNode *sitter.Node) bool {
+	if blockNode == nil || blockNode.Type() != "block" {
+		return false
+	}
+
+	// Iterate over statements in the block from last to first relevant one
+	// Skipping non-code nodes like comments if any.
+	// We are looking for a return statement.
+	// A more sophisticated check would analyze all control flow paths.
+	childCount := int(blockNode.NamedChildCount())
+	if childCount == 0 {
+		return false
+	}
+
+    // Check the last statement(s) of the block.
+    // For now, we simplify and check if the *last* named child is a return statement.
+    // TODO: Handle cases like `if cond: if inner_cond: return; else: return;`
+    // TODO: Handle `try/except/finally` where all paths return.
+	lastStatement := blockNode.NamedChild(childCount - 1)
+	if lastStatement != nil && isReturnStatement(lastStatement) {
+		return true
+	}
+    // A slightly more robust check: if the block is just one statement and it's a return
+    if childCount == 1 && isReturnStatement(blockNode.NamedChild(0)) {
+        return true
+    }
+
+
+	return false
+}
+
+func checkElseAfterReturn(r analysis.Rule, ana *analysis.Analyzer, node *sitter.Node) {
+	if node.Type() != "if_statement" {
+		return
+	}
+
+	consequenceNode := node.ChildByFieldName("consequence") // This is the 'if' block
+	alternativeNode := node.ChildByFieldName("alternative") // This could be an 'elif' or 'else' block
+
+	if alternativeNode == nil {
+		return // No 'else' or 'elif', so rule doesn't apply
+	}
+
+	// We are interested in 'else' blocks, not 'elif'
+	// An 'else' clause is an "else_clause" node containing a "block".
+	// An 'elif' is another "if_statement" node.
+	firstChildOfAlternative := alternativeNode.NamedChild(0)
+	if firstChildOfAlternative == nil || firstChildOfAlternative.Type() != "block" {
+		// This means it's likely an 'elif' (which is an if_statement itself)
+		// or some other structure we are not targeting with this specific 'else' rule.
+		return
+	}
+
+
+	if blockAlwaysReturns(consequenceNode) {
+		ruleID := "py-no-else-after-return" // Define the rule ID string
+		ana.Report(&analysis.Issue{
+			Message: "Unnecessary 'else' after 'return'. The 'if' block always returns.",
+			Range:   alternativeNode.Range(), // Highlight the 'else' keyword or the 'else' block
+			Id:      &ruleID,                 // Pass the address of the rule ID string
+		})
+	}
+}
+
+func NoElseAfterReturn() analysis.Rule {
+	var entry analysis.VisitFn = checkElseAfterReturn
+	// The "if_statement" node type is the correct first argument for CreateRule.
+	// The rule ID "py-no-else-after-return" is used when reporting an issue.
+	return analysis.CreateRule("if_statement", analysis.LangPy, &entry, nil)
+}

--- a/pkg/rules/python/rules.go
+++ b/pkg/rules/python/rules.go
@@ -7,5 +7,6 @@ func CreatePyRules() []analysis.Rule {
 	return []analysis.Rule{
 		IsLiteral(),
 		IfTuple(),
+		NoElseAfterReturn(),
 	}
 }


### PR DESCRIPTION
This commit introduces a new static analysis rule for Python, 'py-no-else-after-return', which flags unnecessary 'else' blocks when the preceding 'if' block always returns.

Key changes:
- Added YAML definition `checkers/py-no-else-after-return.yml` for rule metadata.
- Created Python test cases in `checkers/py-no-else-after-return.test.py`.
- Implemented the core rule logic in Go in `pkg/rules/python/no_else_after_return.go`.
- Registered the new rule in `pkg/rules/python/rules.go`.

Further work is needed to add dedicated Go unit tests for this rule, as the current testing approach does not cover Go-native rule logic. The `blockAlwaysReturns` function in the Go logic is also a simplified version and can be enhanced for more complex scenarios.