### PR TITLE
fix(checkers): load custom YAML checkers from disk, not embedded FS

### DIFF
--- a/checkers/checker.go
+++ b/checkers/checker.go
@@ -13,7 +13,7 @@ import (
 //go:embed **/*.y*ml
 var builtinCheckers embed.FS
 
-func findYamlCheckers(checkersMap map[analysis.Language][]analysis.Analyzer) func(path string, d fs.DirEntry, err error) error {
+func findYamlCheckers(checkersMap map[analysis.Language][]analysis.Analyzer, readFile func(string) ([]byte, error)) func(path string, d fs.DirEntry, err error) error {
 	return func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
@@ -29,7 +29,7 @@ func findYamlCheckers(checkersMap map[analysis.Language][]analysis.Analyzer) fun
 			return nil
 		}
 
-		fileContent, err := builtinCheckers.ReadFile(path)
+		fileContent, err := readFile(path)
 		if err != nil {
 			return nil
 		}
@@ -47,13 +47,15 @@ func findYamlCheckers(checkersMap map[analysis.Language][]analysis.Analyzer) fun
 
 func LoadBuiltinYamlCheckers() (map[analysis.Language][]analysis.Analyzer, error) {
 	checkersMap := make(map[analysis.Language][]analysis.Analyzer)
-	err := fs.WalkDir(builtinCheckers, ".", findYamlCheckers(checkersMap))
+	err := fs.WalkDir(builtinCheckers, ".", findYamlCheckers(checkersMap, builtinCheckers.ReadFile))
 	return checkersMap, err
 }
 
 func LoadCustomYamlCheckers(dir string) (map[analysis.Language][]analysis.Analyzer, error) {
 	checkersMap := make(map[analysis.Language][]analysis.Analyzer)
-	err := fs.WalkDir(os.DirFS(dir), ".", findYamlCheckers(checkersMap))
+	err := fs.WalkDir(os.DirFS(dir), ".", findYamlCheckers(checkersMap, func(p string) ([]byte, error) {
+		return os.ReadFile(filepath.Join(dir, p))
+	}))
 	return checkersMap, err
 }
 

--- a/checkers/checker_test.go
+++ b/checkers/checker_test.go
@@ -1,0 +1,52 @@
+package checkers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"globstar.dev/analysis"
+)
+
+// TestLoadCustomYamlCheckers_ReadsFromDisk is a regression test ensuring that
+// custom YAML checkers are loaded from the local filesystem and not silently
+// dropped because the loader was reading from the embedded FS.
+func TestLoadCustomYamlCheckers_ReadsFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	const yml = `language: go
+name: go_custom_test
+message: "custom checker fired"
+category: security
+severity: critical
+pattern: >
+  [
+    (import_spec
+      path: (interpreted_string_literal) @import
+      (#eq? @import "\"crypto/md5\""))
+  ] @go_custom_test
+`
+	if err := os.WriteFile(filepath.Join(dir, "custom.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	checkersMap, err := LoadCustomYamlCheckers(dir)
+	if err != nil {
+		t.Fatalf("LoadCustomYamlCheckers: %v", err)
+	}
+
+	goCheckers, ok := checkersMap[analysis.LangGo]
+	if !ok || len(goCheckers) == 0 {
+		t.Fatalf("expected at least one Go checker loaded from disk, got map=%v", checkersMap)
+	}
+
+	found := false
+	for _, c := range goCheckers {
+		if c.Name == "go_custom_test" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'go_custom_test' to be loaded; got %+v", goCheckers)
+	}
+}


### PR DESCRIPTION
## Problem

`LoadCustomYamlCheckers(dir)` in `checkers/checker.go` walks
`os.DirFS(dir)` with `fs.WalkDir` to discover YAML files on the local
disk, but the closure it shared with the builtin loader
(`findYamlCheckers`) read file content via
`builtinCheckers.ReadFile(path)` — i.e. always the embedded FS, never
the local filesystem.

For every custom YAML file, `ReadFile` returned `fs.ErrNotExist`, the
error was silently swallowed by the top-level error check in the walk
callback (`if err != nil { return nil }`), and the checker was never
loaded. Net result: `globstar check --checkers=local` in a repo with a
`.globstar/*.yml` found zero issues regardless of the YAML's content.

### Reproduction (against v0.7.0)

```bash
mkdir -p /tmp/repro/.globstar
# copy any working built-in YAML (e.g. checkers/go/md5_weak_hash.yml)
# into /tmp/repro/.globstar/
cat > /tmp/repro/test.go <<'GO'
package main
import "crypto/md5"
func main() { _ = md5.New() }
GO
cd /tmp/repro && globstar check --checkers=local
# -> 0 issues (should have fired, same YAML fires via --checkers=builtin)
```

## Fix

Thread a per-backend `readFile func(string) ([]byte, error)` through
`findYamlCheckers`:

- `LoadBuiltinYamlCheckers` passes `builtinCheckers.ReadFile`
- `LoadCustomYamlCheckers` passes a closure that reads from disk via
  `os.ReadFile(filepath.Join(dir, p))`

No public API changes — only the unexported helper signature changes.

## Tests

- Added `checkers/checker_test.go` with `TestLoadCustomYamlCheckers_ReadsFromDisk`,
  which writes a YAML checker to a `t.TempDir()` and asserts the
  checker is returned in the language map. Verified the test fails on
  the pre-fix code and passes after.
- `go test ./checkers/... ./analysis/... ./pkg/...` all pass.
- `make generate-registry && go build ./cmd/globstar` builds cleanly.