### PR TITLE
fix(cli): execute YAML pattern analyzers during analysis

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -431,17 +431,19 @@ func (c *Cli) RunCheckers(runBuiltinCheckers, runCustomCheckers bool) error {
 		return err
 	}
 
+	fileFilter := func(filename string) bool {
+		if c.CmpHash != "" {
+			_, isChanged := changedFileMap[filename]
+			return isChanged
+		}
+		return true
+	}
+
 	if len(goAnalyzers) > 0 {
 		goIssues, err := analysis.RunAnalyzers(
 			c.RootDirectory,
 			goAnalyzers,
-			func(filename string) bool {
-				if c.CmpHash != "" {
-					_, isChanged := changedFileMap[filename]
-					return isChanged
-				}
-				return true
-			},
+			fileFilter,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to run Go-based analyzers: %w", err)
@@ -455,6 +457,54 @@ func (c *Cli) RunCheckers(runBuiltinCheckers, runCustomCheckers bool) error {
 				Message:  issue.Message,
 				Severity: analysis.Severity(issue.Severity),
 				Category: analysis.Category(issue.Category),
+				Node:     issue.Node,
+				Id:       issue.Id,
+			})
+		}
+	}
+
+	// Flatten the per-language pattern checkers map into a slice and run them
+	// against the project. Without this step, YAML pattern checkers (both
+	// built-in and custom) are loaded but never executed.
+	var yamlAnalyzers []*analysis.Analyzer
+	yamlAnalyzerByName := make(map[string]*analysis.Analyzer)
+	for _, checkers := range patternCheckers {
+		for i := range checkers {
+			analyzer := &checkers[i]
+			yamlAnalyzers = append(yamlAnalyzers, analyzer)
+			yamlAnalyzerByName[analyzer.Name] = analyzer
+		}
+	}
+
+	if len(yamlAnalyzers) > 0 {
+		yamlIssues, err := analysis.RunAnalyzers(
+			c.RootDirectory,
+			yamlAnalyzers,
+			fileFilter,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to run YAML pattern analyzers: %w", err)
+		}
+		for _, issue := range yamlIssues {
+			txt, _ := issue.AsText()
+			log.Error().Msg(string(txt))
+
+			// Look up the originating analyzer so we can preserve severity
+			// and category on the reported issue.
+			severity := analysis.Severity(issue.Severity)
+			category := analysis.Category(issue.Category)
+			if issue.Id != nil {
+				if a, ok := yamlAnalyzerByName[*issue.Id]; ok {
+					severity = a.Severity
+					category = a.Category
+				}
+			}
+
+			result.issues = append(result.issues, &analysis.Issue{
+				Filepath: issue.Filepath,
+				Message:  issue.Message,
+				Severity: severity,
+				Category: category,
 				Node:     issue.Node,
 				Id:       issue.Id,
 			})

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"globstar.dev/pkg/config"
+)
+
+// TestRunCheckers_ExecutesCustomYamlCheckers is a regression test ensuring
+// that YAML pattern checkers loaded from a user's .globstar directory are
+// actually executed against project files. Previously, RunCheckers loaded
+// the checkers into a map but never passed them to the analyzer runner, so
+// custom YAML rules silently produced zero findings.
+func TestRunCheckers_ExecutesCustomYamlCheckers(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	checkerDir := filepath.Join(tmpDir, ".globstar")
+	if err := os.MkdirAll(checkerDir, 0o755); err != nil {
+		t.Fatalf("mkdir .globstar: %v", err)
+	}
+
+	const yamlChecker = `language: go
+name: go_filepath_clean_test
+message: "Found filepath.Clean"
+category: security
+severity: critical
+pattern: >
+  (call_expression
+    function: (selector_expression
+      operand: (identifier) @pkg
+      field: (field_identifier) @func
+    )
+    (#eq? @pkg "filepath")
+    (#eq? @func "Clean")
+  ) @go_filepath_clean_test
+`
+	if err := os.WriteFile(filepath.Join(checkerDir, "my_check.yml"), []byte(yamlChecker), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	const goSource = `package main
+
+import "path/filepath"
+
+func main() {
+	_ = filepath.Clean("x")
+}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "test.go"), []byte(goSource), 0o644); err != nil {
+		t.Fatalf("write go file: %v", err)
+	}
+
+	conf := &config.Config{}
+	conf.PopulateDefaults()
+	conf.CheckerDir = checkerDir
+
+	c := &Cli{
+		RootDirectory: tmpDir,
+		Config:        conf,
+	}
+
+	err := c.RunCheckers(false, true)
+	// A critical issue should be raised, which by default causes RunCheckers
+	// to return a non-nil error ("found N issues") via FailWhen. If the YAML
+	// execution bug returns, no issues are produced and err would be nil.
+	require.Error(t, err, "expected RunCheckers to report a finding from the custom YAML checker")
+	require.Contains(t, err.Error(), "found 1 issues")
+}


### PR DESCRIPTION
## Problem

`RunCheckers` in `pkg/cli/cli.go` loads built-in and custom YAML pattern checkers into a `patternCheckers` map, but the map is never passed to `analysis.RunAnalyzers`. Only Go-based analyzers (from `LoadGoCheckers()` and the custom Go stub) are executed end-to-end.

The result: every YAML-defined rule — whether built-in under `checkers/**/*.yml` or custom under `.globstar/*.yml` — silently produces zero findings. This is the follow-up bug noted in #230: after that PR fixed the YAML loader, loaded checkers still weren't reaching the analyzer runtime.

Reproduced against master with a trivial custom YAML rule and matching Go fixture: 0 issues reported. Same symptom for built-in YAML rules (e.g. `go_des_weak_crypto`) against obviously-violating source.

## Fix

After the Go analyzer pass, flatten `patternCheckers` into `[]*analysis.Analyzer` and call `analysis.RunAnalyzers` with the same file filter used for Go analyzers. Preserve `Severity` / `Category` on the resulting issues by looking up the originating analyzer by name (the runtime populates `Issue.Id` from `Analyzer.Name` but does not copy severity/category).

Minimal change, no refactor — the `fileFilter` closure is hoisted once so both runs share it.

## Tests

- New `TestRunCheckers_ExecutesCustomYamlCheckers` in `pkg/cli/cli_test.go` writes a YAML rule to a temp `.globstar`, writes a matching Go file, constructs a `Cli`, invokes `RunCheckers(false, true)`, and asserts a finding is produced. Verified this test fails on master (0 issues) and passes with the fix.
- Full `go test ./...` — the two pre-existing failures (`checkers/go` has YAML test fixtures that confuse the Go toolchain, `checkers/discover/custom_analyzer_stub` is a template requiring generated symbols) are present on clean master and unrelated to this change.
- Smoke-tested the built binary end-to-end:
  - `./globstar check --checkers=local` against a minimal custom rule: 1 issue reported, exit 1.
  - `./globstar check --checkers=builtin` against a `des.NewCipher` call: built-in `go_des_weak_crypto` fires correctly.