### PR TITLE
fix(analysis): assign AstNode to the scope a node introduces

### DIFF
--- a/analysis/scope.go
+++ b/analysis/scope.go
@@ -146,10 +146,11 @@ func buildScopeTree(
 	nextScope := scope
 	if builder.NodeCreatesScope(node) {
 		nextScope = NewScope(scope)
+		// AstNode belongs to the scope this node introduces, not to its parent.
+		nextScope.AstNode = node
 		scopeOfNode[node] = nextScope
 		if scope != nil {
 			scope.Children = append(scope.Children, nextScope)
-			scope.AstNode = node
 		} else {
 			scope = nextScope // root
 		}

--- a/analysis/ts_scope_test.go
+++ b/analysis/ts_scope_test.go
@@ -135,6 +135,53 @@ func Test_BuildScopeTree(t *testing.T) {
 
 }
 
+func Test_ScopeAstNode(t *testing.T) {
+	// Scope.AstNode is documented as "the AST node that introduces this scope
+	// into the scope tree", so every scope in the tree must point at its own
+	// introducing node.
+	source := `
+		let x = 1
+		function f() {
+			let y = 2
+		}
+		{
+			let z = 3
+		}`
+	parsed := parseFile(t, source)
+	scopeTree := MakeScopeTree(parsed.Language, parsed.Ast, parsed.Source)
+	require.NotNil(t, scopeTree)
+
+	t.Run("every scope points at the node that introduces it", func(t *testing.T) {
+		for node, scope := range scopeTree.ScopeOfNode {
+			require.NotNil(t, scope.AstNode,
+				"scope introduced by %q has a nil AstNode", node.Type())
+			assert.Equal(t, node, scope.AstNode,
+				"scope introduced by %q points at %q instead",
+				node.Type(), scope.AstNode.Type())
+		}
+	})
+
+	t.Run("a parent scope is not overwritten by its children", func(t *testing.T) {
+		// The program scope has two scope-creating children (the function and
+		// the bare block); neither may claim the program scope's AstNode.
+		programScope := scopeTree.Root.Children[0]
+		require.NotNil(t, programScope.AstNode)
+		assert.Equal(t, "program", programScope.AstNode.Type())
+		require.Len(t, programScope.Children, 2)
+	})
+
+	t.Run("a function scope points at the function, not at its body", func(t *testing.T) {
+		globalScope := scopeTree.Root.Children[0]
+		funcVar := globalScope.Lookup("f")
+		require.NotNil(t, funcVar)
+
+		funcScope := scopeTree.GetScope(funcVar.DeclNode)
+		require.NotNil(t, funcScope)
+		require.NotNil(t, funcScope.AstNode)
+		assert.Equal(t, "function_declaration", funcScope.AstNode.Type())
+	})
+}
+
 func TestExportHandling(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Description

`Scope.AstNode` is documented as *"the AST node that introduces this scope into the scope tree"*, but `buildScopeTree` assigned it on the **parent** scope rather than on the scope the node actually introduces:

```go
nextScope = NewScope(scope)
scopeOfNode[node] = nextScope
if scope != nil {
    scope.Children = append(scope.Children, nextScope)
    scope.AstNode = node   // <- parent's field, not nextScope's
}
```

Two things follow from that:

- a newly created scope's own `AstNode` was never assigned, so every scope in the tree reported `nil` except the synthetic root
- a parent's `AstNode` was reassigned by each scope-creating child in turn, so it ended up holding whichever child was visited last

### Reproduction

For this source:

```js
let x = 1
function f() {
    let y = 2
}
{
    let z = 3
}
```

walking `ScopeOfNode` on `master` gives:

| scope introduced by | `AstNode` reported | expected |
|---|---|---|
| `program` | `statement_block` | `program` |
| `function_declaration` | `statement_block` (its own body) | `function_declaration` |
| `statement_block` | `nil` | `statement_block` |
| `statement_block` | `nil` | `statement_block` |

### Fix

Assign `nextScope.AstNode = node`. `ScopeOfNode` already mapped each node to the correct scope, so `GetScope` was never affected and nothing that relies on it changes behaviour — this only makes the field match its documented meaning.

I found this while reading `ScopeBuilder` to understand how scope resolution works before writing a checker. The field is exported on an exported type, so checker authors reaching for `scope.AstNode` currently get `nil` or the wrong node; that seemed worth fixing even though nothing in-tree reads it today.

## Type of change
- [x] Bug fix
- [ ] New feature/enhancement
- [ ] New checker
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [ ] I have updated the documentation, if applicable
- [ ] All new checkers are in the `checkers` directory
- [x] I have added tests, if applicable
- [x] I have tested my changes (run `make testall`)
- [ ] Checker YAML files follow the required format
- [x] CI checks are passing

`Test_ScopeAstNode` walks `ScopeOfNode` and asserts every scope points at its own introducing node, with explicit subtests for the parent-overwrite and function-vs-body cases. It fails on `master` with:

```
scope introduced by "program" points at "statement_block" instead
scope introduced by "function_declaration" points at "statement_block" instead
scope introduced by "statement_block" has a nil AstNode
```

and passes with the fix.

On my machine (Windows) `TestFindYamlTestFiles` fails both before and after this change, so it looks unrelated and pre-existing rather than something this PR introduces — happy to look into it separately if that's useful.

## Related Issues

None.

## Additional Notes

This PR was developed with AI assistance (Claude); the bug was found by reading the scope builder, and the fix and tests were reviewed and verified locally before submission.
